### PR TITLE
feat: add payment system (AbacatePay PIX + PagSeguro Payout)

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -1,0 +1,296 @@
+# SemeiaRS - Agent Documentation
+
+## 1. Project Identity
+
+**Name**: SemeiaRS  
+**Type**: C2C E-commerce Marketplace (MVP)  
+**Purpose**: Consumer-to-consumer marketplace that will evolve to support family farmers in Rio Grande do Sul, Brazil  
+**Version**: 0.1.0
+
+---
+
+## 2. Technology Stack
+
+| Layer | Technology |
+|-------|------------|
+| Framework | Next.js 16 (App Router) |
+| Language | TypeScript |
+| Database | PostgreSQL |
+| ORM | Prisma |
+| Auth | NextAuth.js (Auth.js) |
+| Styling | Tailwind CSS |
+| Validation | Zod |
+| UI Components | shadcn/ui + Radix UI |
+
+---
+
+## 3. Current Features (MVP)
+
+- User authentication (register, login, logout)
+- Product catalog with search and category filters
+- Full CRUD for products (sellers)
+- Shopping cart (persisted in database)
+- Order management for buyers and sellers
+- Order status timeline (7 status states)
+- Responsive design system
+- Full Portuguese Brazilian localization
+
+---
+
+## 4. Planned Features
+
+- Image upload (Firebase Storage or S3)
+- Payment integration (AbacatePay + PagSeguro Payout)
+- Seller payment settings (PIX configuration)
+- Payout/split automation
+
+---
+
+## 5. Database Schema (Core Entities)
+
+```
+User → Products (hasMany)
+User → Orders (hasMany)
+Order → OrderItems (hasMany)
+Product → Category (belongsTo)
+Product → User (belongsTo)
+```
+
+### Core Models
+- **User**: id, name, email, password, phone, address, role (BUYER/SELLER)
+- **Product**: id, name, description, basePrice, currentPrice, quantity, imageUrl, sellerId, categoryId
+- **Category**: id, name
+- **Order**: id, buyerId, total, status, createdAt
+- **OrderItem**: id, orderId, productId, quantity, price
+- **Cart**: id, userId, productId, quantity
+
+---
+
+## 6. Design System
+
+### Colors (Tailwind Tokens)
+
+| Token | Hex | Usage |
+|-------|-----|-------|
+| `--primary` | #4a7c6f | Main actions, links (Forest Green) |
+| `--primary-foreground` | #f7f5f2 | Text on primary |
+| `--secondary` | #ece8e0 | Cards, sections (Warm Beige) |
+| `--secondary-foreground` | #4a4540 | Text on secondary |
+| `--accent` | #d98c4d | CTAs, highlights (Terracotta) |
+| `--accent-foreground` | #f7f5f2 | Text on accent |
+| `--earth` | #6b5c4d | Dark accents |
+| `--warm-yellow` | #e8c06a | Highlights |
+| `--background` | #f7f5f2 | Page background |
+| `--foreground` | #3d3632 | Primary text |
+| `--border` | #ddd8cf | Borders |
+| `--muted` | #ece8e0 | Muted backgrounds |
+| `--muted-foreground` | #8a817a | Secondary text |
+| `--destructive` | #dc2626 | Error states |
+
+### Typography
+
+| Element | Font Family |
+|---------|-------------|
+| Headings (h1-h6) | Poppins |
+| Body text | Inter |
+
+### Component Patterns
+
+- Border radius: `0.75rem` (12px)
+- Container max-width: `1400px`
+- Section padding: `py-16 md:py-24 px-4 md:px-8`
+
+---
+
+## 7. Payment Architecture
+
+### Flow
+
+1. **Buyer pays** via AbacatePay (PIX)
+2. **Payment confirmed** via webhook or polling
+3. **Backend calculates split** (10% commission)
+4. **Payout** via PagSeguro Payout API
+
+### Fees
+
+| Item | Value |
+|------|-------|
+| AbacatePay fee | R$ 0.80/transaction |
+| Platform fee | R$ 0.20/transaction |
+| Commission | 10% of seller amount |
+| **Total** | **R$ 1.00 per sale** |
+
+### Planned Payment Models
+
+```prisma
+model SellerPayment {
+  id          String  @id
+  sellerId    String  @unique
+  cpfCnpj     String
+  pixKey      String  // encrypted
+  pixKeyType  String  // CPF, CNPJ, EMAIL, TELEFONE
+  isVerified  Boolean
+}
+
+model Payment {
+  id            String
+  orderId       String  @unique
+  amount        Float
+  status        String  // PENDING, WAITING, CONFIRMED, FAILED
+  splits        PaymentSplit[]
+}
+
+model PaymentSplit {
+  id          String
+  paymentId   String
+  sellerId    String
+  grossAmount Float
+  commission  Float
+  netAmount   Float
+  payoutStatus String
+}
+
+model Payout {
+  id            String
+  sellerId      String
+  amount       Float
+  status       String  // PENDING, PROCESSING, SUCCESS, FAILED
+  errorMessage  String?
+}
+```
+
+---
+
+## 8. Development Workflow
+
+### Plan Mode
+
+- Enter plan mode for ANY non-trivial task (3+ steps or architectural decisions)
+- If something goes wrong, STOP and re-plan immediately
+- Write detailed specs upfront to reduce ambiguity
+
+### Subagent Strategy
+
+- Use subagents liberally to keep main context clean
+- Offload research, exploration, and parallel analysis to subagents
+
+### Verification
+
+- Never mark a task complete without proving it works
+- Ask: "Would a staff engineer approve this?"
+- Run tests, check logs, demonstrate correctness
+
+### Self-Improvement
+
+- After any correction: update lessons learned
+- Write rules to prevent same mistakes
+
+---
+
+## 9. Coding Standards
+
+- Follow clean/hexagonal architecture patterns
+- Prioritize server-side rendering (RSC)
+- Implement caching early
+- Test incrementally
+- Use Zod for validation
+- All new code must pass lint before marking complete
+
+---
+
+## 10. Commands
+
+### Development
+
+```bash
+npm run dev          # Start development server
+npm run build        # Production build
+npm run start        # Start production server
+```
+
+### Database
+
+```bash
+npx prisma generate  # Generate Prisma Client
+npx prisma migrate dev   # Run migrations
+npm run db:seed      # Seed database with test data
+```
+
+### Code Quality
+
+```bash
+npm run lint         # Run ESLint
+```
+
+### Test Accounts (after seed)
+
+| Role | Email | Password |
+|------|-------|----------|
+| Seller | joao.silva@email.com | senha123 |
+| Seller | maria.santos@email.com | senha123 |
+| Seller | pedro.oliveira@email.com | senha123 |
+| Seller | ana.ferreira@email.com | senha123 |
+| Buyer | comprador@email.com | senha123 |
+
+---
+
+## 11. Project Structure
+
+```
+src/
+├── app/                    # Next.js App Router
+│   ├── api/               # API Routes
+│   │   ├── auth/         # NextAuth endpoints
+│   │   └── seller/       # Seller API
+│   ├── cart/             # Shopping cart
+│   ├── login/            # Login page
+│   ├── orders/           # Buyer orders
+│   ├── products/         # Product catalog
+│   ├── profile/          # User profile
+│   ├── register/         # Registration
+│   ├── seller/           # Seller area
+│   │   └── orders/       # Seller orders
+├── actions/               # Server Actions
+├── components/            # React components
+├── lib/                   # Utilities
+│   ├── auth.ts           # NextAuth config
+│   ├── messages.ts       # Localization
+│   └── prisma.ts         # Prisma client
+└── types/                # TypeScript definitions
+```
+
+---
+
+## 12. Environment Variables
+
+```env
+DATABASE_URL="postgresql://user:password@localhost:5432/semeiars"
+NEXTAUTH_SECRET="your-secret-key"
+NEXTAUTH_URL="http://localhost:3000"
+```
+
+---
+
+## 13. Roadmap
+
+### v0.1.0 - MVP (Current)
+- [x] Authentication
+- [x] Product catalog
+- [x] Shopping cart
+- [x] Order management
+- [x] Design system
+- [x] Portuguese localization
+- [ ] Image upload
+
+### v1.0 - Family Farming
+- [ ] Payment integration (AbacatePay + PagSeguro)
+- [ ] Split system between sellers
+- [ ] Farmer validation
+- [ ] Seller dashboard
+- [ ] Sales reports
+
+### v2.0 - Expansion
+- [ ] Review/rating system
+- [ ] Buyer-seller chat
+- [ ] Messaging system
+- [ ] Invoice generation

--- a/prisma/migrations/20260313175502_add_payment_tables/migration.sql
+++ b/prisma/migrations/20260313175502_add_payment_tables/migration.sql
@@ -1,0 +1,101 @@
+-- CreateEnum
+CREATE TYPE "PaymentStatus" AS ENUM ('PENDING', 'WAITING', 'CONFIRMED', 'FAILED');
+
+-- CreateEnum
+CREATE TYPE "PaymentSplitStatus" AS ENUM ('PENDING', 'PROCESSING', 'SENT', 'SUCCESS', 'FAILED');
+
+-- CreateEnum
+CREATE TYPE "PayoutStatus" AS ENUM ('PENDING', 'PROCESSING', 'SUCCESS', 'FAILED');
+
+-- CreateEnum
+CREATE TYPE "PixKeyType" AS ENUM ('CPF', 'CNPJ', 'EMAIL', 'TELEFONE');
+
+-- CreateTable
+CREATE TABLE "SellerPayment" (
+    "id" TEXT NOT NULL,
+    "sellerId" TEXT NOT NULL,
+    "cpfCnpj" TEXT NOT NULL,
+    "pixKey" TEXT NOT NULL,
+    "pixKeyType" "PixKeyType" NOT NULL,
+    "pixBank" TEXT,
+    "isVerified" BOOLEAN NOT NULL DEFAULT false,
+    "isActive" BOOLEAN NOT NULL DEFAULT true,
+    "termsAccepted" BOOLEAN NOT NULL DEFAULT false,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "SellerPayment_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Payment" (
+    "id" TEXT NOT NULL,
+    "orderId" TEXT NOT NULL,
+    "buyerId" TEXT NOT NULL,
+    "abacatePayId" TEXT,
+    "amount" DOUBLE PRECISION NOT NULL,
+    "status" "PaymentStatus" NOT NULL DEFAULT 'PENDING',
+    "pixCopyPaste" TEXT,
+    "pixQrCode" TEXT,
+    "paymentUrl" TEXT,
+    "paidAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Payment_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "PaymentSplit" (
+    "id" TEXT NOT NULL,
+    "paymentId" TEXT NOT NULL,
+    "sellerId" TEXT NOT NULL,
+    "grossAmount" DOUBLE PRECISION NOT NULL,
+    "commission" DOUBLE PRECISION NOT NULL,
+    "netAmount" DOUBLE PRECISION NOT NULL,
+    "payoutId" TEXT,
+    "payoutStatus" "PaymentSplitStatus",
+    "paidAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "PaymentSplit_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Payout" (
+    "id" TEXT NOT NULL,
+    "sellerId" TEXT NOT NULL,
+    "paymentSplitId" TEXT NOT NULL,
+    "amount" DOUBLE PRECISION NOT NULL,
+    "pagseguroId" TEXT,
+    "status" "PayoutStatus" NOT NULL DEFAULT 'PENDING',
+    "errorMessage" TEXT,
+    "processedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "Payout_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "SellerPayment_sellerId_key" ON "SellerPayment"("sellerId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Payment_orderId_key" ON "Payment"("orderId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Payout_paymentSplitId_key" ON "Payout"("paymentSplitId");
+
+-- AddForeignKey
+ALTER TABLE "SellerPayment" ADD CONSTRAINT "SellerPayment_sellerId_fkey" FOREIGN KEY ("sellerId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Payment" ADD CONSTRAINT "Payment_orderId_fkey" FOREIGN KEY ("orderId") REFERENCES "Order"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "PaymentSplit" ADD CONSTRAINT "PaymentSplit_paymentId_fkey" FOREIGN KEY ("paymentId") REFERENCES "Payment"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Payout" ADD CONSTRAINT "Payout_sellerId_fkey" FOREIGN KEY ("sellerId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Payout" ADD CONSTRAINT "Payout_paymentSplitId_fkey" FOREIGN KEY ("paymentSplitId") REFERENCES "PaymentSplit"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -21,6 +21,35 @@ enum OrderStatus {
   CANCELLED
 }
 
+enum PaymentStatus {
+  PENDING
+  WAITING
+  CONFIRMED
+  FAILED
+}
+
+enum PaymentSplitStatus {
+  PENDING
+  PROCESSING
+  SENT
+  SUCCESS
+  FAILED
+}
+
+enum PayoutStatus {
+  PENDING
+  PROCESSING
+  SUCCESS
+  FAILED
+}
+
+enum PixKeyType {
+  CPF
+  CNPJ
+  EMAIL
+  TELEFONE
+}
+
 model User {
   id        String    @id @default(cuid())
   name      String
@@ -32,10 +61,12 @@ model User {
   createdAt DateTime  @default(now())
   updatedAt DateTime  @updatedAt
 
-  products    Product[]
-  orders      Order[]
-  cart        Cart?
-  sellerOrders SellerOrder[]
+  products      Product[]
+  orders        Order[]
+  cart          Cart?
+  sellerOrders  SellerOrder[]
+  sellerPayment SellerPayment?
+  payouts       Payout[]
 }
 
 model Category {
@@ -78,6 +109,7 @@ model Order {
 
   items       OrderItem[]
   sellerOrders SellerOrder[]
+  payment     Payment?
 }
 
 model OrderItem {
@@ -131,4 +163,67 @@ model SellerOrder {
   updatedAt          DateTime    @updatedAt
 
   @@unique([orderId, sellerId])
+}
+
+model SellerPayment {
+  id              String      @id @default(cuid())
+  sellerId        String      @unique
+  seller          User        @relation(fields: [sellerId], references: [id], onDelete: Cascade)
+  cpfCnpj         String
+  pixKey          String
+  pixKeyType      PixKeyType
+  pixBank         String?
+  isVerified      Boolean     @default(false)
+  isActive        Boolean     @default(true)
+  termsAccepted   Boolean     @default(false)
+  createdAt       DateTime    @default(now())
+  updatedAt       DateTime    @updatedAt
+}
+
+model Payment {
+  id              String        @id @default(cuid())
+  orderId         String        @unique
+  order           Order         @relation(fields: [orderId], references: [id], onDelete: Cascade)
+  buyerId         String
+  abacatePayId   String?
+  amount          Float
+  status          PaymentStatus @default(PENDING)
+  pixCopyPaste   String?
+  pixQrCode       String?
+  paymentUrl      String?
+  paidAt          DateTime?
+  createdAt       DateTime      @default(now())
+  updatedAt       DateTime      @updatedAt
+
+  splits          PaymentSplit[]
+}
+
+model PaymentSplit {
+  id            String            @id @default(cuid())
+  paymentId     String
+  payment       Payment           @relation(fields: [paymentId], references: [id], onDelete: Cascade)
+  sellerId      String
+  grossAmount   Float
+  commission    Float
+  netAmount     Float
+  payoutId      String?
+  payoutStatus  PaymentSplitStatus?
+  paidAt        DateTime?
+  createdAt     DateTime          @default(now())
+
+  payout        Payout?
+}
+
+model Payout {
+  id              String        @id @default(cuid())
+  sellerId        String
+  seller          User          @relation(fields: [sellerId], references: [id])
+  paymentSplitId  String        @unique
+  paymentSplit    PaymentSplit  @relation(fields: [paymentSplitId], references: [id], onDelete: Cascade)
+  amount          Float
+  pagseguroId    String?
+  status         PayoutStatus  @default(PENDING)
+  errorMessage    String?
+  processedAt     DateTime?
+  createdAt       DateTime      @default(now())
 }

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -12,6 +12,22 @@ const prisma = new PrismaClient({ adapter })
 async function main() {
   console.log('Iniciando seed...')
 
+  // Limpar dados existentes (ordem respeitando foreign keys)
+  console.log('Limpando dados existentes...')
+  await prisma.payout.deleteMany()
+  await prisma.paymentSplit.deleteMany()
+  await prisma.payment.deleteMany()
+  await prisma.sellerOrder.deleteMany()
+  await prisma.orderItem.deleteMany()
+  await prisma.order.deleteMany()
+  await prisma.cartItem.deleteMany()
+  await prisma.cart.deleteMany()
+  await prisma.sellerPayment.deleteMany()
+  await prisma.product.deleteMany()
+  await prisma.category.deleteMany()
+  await prisma.user.deleteMany()
+  console.log('Dados limpos.')
+
   // Criar categorias agrícolas
   const categories = await Promise.all([
     prisma.category.upsert({
@@ -319,6 +335,262 @@ async function main() {
   })
 
   console.log('Comprador de teste criado:', buyer.email)
+
+  // Criar configurações de pagamento PIX para vendedores
+  const pixSettings = await Promise.all([
+    prisma.sellerPayment.upsert({
+      where: { sellerId: sellers[0].id },
+      update: {},
+      create: {
+        sellerId: sellers[0].id,
+        cpfCnpj: '12345678901',
+        pixKey: 'encrypted:joao.silva@email.com',
+        pixKeyType: 'EMAIL',
+        pixBank: 'Banrisul',
+        isActive: true,
+        isVerified: false,
+        termsAccepted: true,
+      },
+    }),
+    prisma.sellerPayment.upsert({
+      where: { sellerId: sellers[1].id },
+      update: {},
+      create: {
+        sellerId: sellers[1].id,
+        cpfCnpj: '98765432100',
+        pixKey: 'encrypted:maria.santos@email.com',
+        pixKeyType: 'EMAIL',
+        pixBank: 'Sicredi',
+        isActive: true,
+        isVerified: false,
+        termsAccepted: true,
+      },
+    }),
+    prisma.sellerPayment.upsert({
+      where: { sellerId: sellers[2].id },
+      update: {},
+      create: {
+        sellerId: sellers[2].id,
+        cpfCnpj: '45678912300',
+        pixKey: 'encrypted:pedro.oliveira@email.com',
+        pixKeyType: 'EMAIL',
+        pixBank: 'Bradesco',
+        isActive: true,
+        isVerified: false,
+        termsAccepted: true,
+      },
+    }),
+    prisma.sellerPayment.upsert({
+      where: { sellerId: sellers[3].id },
+      update: {},
+      create: {
+        sellerId: sellers[3].id,
+        cpfCnpj: '78912345600',
+        pixKey: 'encrypted:ana.ferreira@email.com',
+        pixKeyType: 'EMAIL',
+        pixBank: 'Itaú',
+        isActive: true,
+        isVerified: false,
+        termsAccepted: true,
+      },
+    }),
+  ])
+
+  console.log('Configurações PIX criadas:', pixSettings.length)
+
+  // Criar pedidos de exemplo com pagamentos
+  const allProducts = await prisma.product.findMany()
+  
+  // Pedido 1: Completed com pagamento confirmado
+  const order1 = await prisma.order.create({
+    data: {
+      buyerId: buyer.id,
+      totalAmount: 89.50,
+      status: 'COMPLETED',
+      items: {
+        create: [
+          {
+            productId: allProducts[0].id,
+            quantity: 5,
+            price: allProducts[0].currentPrice,
+          },
+          {
+            productId: allProducts[6].id,
+            quantity: 3,
+            price: allProducts[6].currentPrice,
+          },
+        ],
+      },
+    },
+  })
+
+  // SellerOrder para pedido 1
+  await prisma.sellerOrder.createMany({
+    data: [
+      { orderId: order1.id, sellerId: sellers[0].id, status: 'COMPLETED' },
+      { orderId: order1.id, sellerId: sellers[2].id, status: 'COMPLETED' },
+    ],
+    skipDuplicates: true,
+  })
+
+  // Payment para pedido 1 (confirmado)
+  const payment1 = await prisma.payment.create({
+    data: {
+      orderId: order1.id,
+      buyerId: buyer.id,
+      amount: 89.50,
+      status: 'CONFIRMED',
+      abacatePayId: 'charge_example_001',
+      paidAt: new Date(Date.now() - 2 * 24 * 60 * 60 * 1000),
+    },
+  })
+
+  // PaymentSplits para pedido 1
+  await prisma.paymentSplit.createMany({
+    data: [
+      {
+        paymentId: payment1.id,
+        sellerId: sellers[0].id,
+        grossAmount: 39.50,
+        commission: 3.95,
+        netAmount: 35.55,
+        payoutStatus: 'SUCCESS',
+        paidAt: new Date(Date.now() - 1 * 24 * 60 * 60 * 1000),
+      },
+      {
+        paymentId: payment1.id,
+        sellerId: sellers[2].id,
+        grossAmount: 50.00,
+        commission: 5.00,
+        netAmount: 45.00,
+        payoutStatus: 'SUCCESS',
+        paidAt: new Date(Date.now() - 1 * 24 * 60 * 60 * 1000),
+      },
+    ],
+  })
+
+  // Payouts para pedido 1
+  const payouts1 = await prisma.payout.createMany({
+    data: [
+      {
+        sellerId: sellers[0].id,
+        paymentSplitId: (await prisma.paymentSplit.findFirst({ where: { paymentId: payment1.id, sellerId: sellers[0].id } }))!.id,
+        amount: 35.55,
+        pagseguroId: 'payout_001',
+        status: 'SUCCESS',
+        processedAt: new Date(Date.now() - 1 * 24 * 60 * 60 * 1000),
+      },
+      {
+        sellerId: sellers[2].id,
+        paymentSplitId: (await prisma.paymentSplit.findFirst({ where: { paymentId: payment1.id, sellerId: sellers[2].id } }))!.id,
+        amount: 45.00,
+        pagseguroId: 'payout_002',
+        status: 'SUCCESS',
+        processedAt: new Date(Date.now() - 1 * 24 * 60 * 60 * 1000),
+      },
+    ],
+  })
+
+  // Pedido 2: Em andamento (confirmado, preparando)
+  const order2 = await prisma.order.create({
+    data: {
+      buyerId: buyer.id,
+      totalAmount: 62.80,
+      status: 'PREPARING',
+      items: {
+        create: [
+          {
+            productId: allProducts[3].id,
+            quantity: 2,
+            price: allProducts[3].currentPrice,
+          },
+          {
+            productId: allProducts[4].id,
+            quantity: 2,
+            price: allProducts[4].currentPrice,
+          },
+        ],
+      },
+    },
+  })
+
+  await prisma.sellerOrder.createMany({
+    data: [
+      { orderId: order2.id, sellerId: sellers[1].id, status: 'PREPARING' },
+    ],
+    skipDuplicates: true,
+  })
+
+  const payment2 = await prisma.payment.create({
+    data: {
+      orderId: order2.id,
+      buyerId: buyer.id,
+      amount: 62.80,
+      status: 'CONFIRMED',
+      abacatePayId: 'charge_example_002',
+      paidAt: new Date(Date.now() - 12 * 60 * 60 * 1000),
+    },
+  })
+
+  await prisma.paymentSplit.create({
+    data: {
+      paymentId: payment2.id,
+      sellerId: sellers[1].id,
+      grossAmount: 62.80,
+      commission: 6.28,
+      netAmount: 56.52,
+      payoutStatus: 'PENDING',
+    },
+  })
+
+  // Pedido 3: Pago, aguardando preparo
+  const order3 = await prisma.order.create({
+    data: {
+      buyerId: buyer.id,
+      totalAmount: 42.00,
+      status: 'CONFIRMED',
+      items: {
+        create: [
+          {
+            productId: allProducts[7].id,
+            quantity: 1,
+            price: allProducts[7].currentPrice,
+          },
+        ],
+      },
+    },
+  })
+
+  await prisma.sellerOrder.createMany({
+    data: [
+      { orderId: order3.id, sellerId: sellers[2].id, status: 'CONFIRMED' },
+    ],
+    skipDuplicates: true,
+  })
+
+  const payment3 = await prisma.payment.create({
+    data: {
+      orderId: order3.id,
+      buyerId: buyer.id,
+      amount: 42.00,
+      status: 'CONFIRMED',
+      abacatePayId: 'charge_example_003',
+      paidAt: new Date(Date.now() - 6 * 60 * 60 * 1000),
+    },
+  })
+
+  await prisma.paymentSplit.create({
+    data: {
+      paymentId: payment3.id,
+      sellerId: sellers[2].id,
+      grossAmount: 42.00,
+      commission: 4.20,
+      netAmount: 37.80,
+      payoutStatus: 'PENDING',
+    },
+  })
+
+  console.log('Pedidos de exemplo criados: 3')
   console.log('Seed concluído com sucesso!')
 }
 

--- a/src/actions/category.ts
+++ b/src/actions/category.ts
@@ -5,7 +5,7 @@ import { prisma } from '@/lib/prisma'
 import { revalidatePath } from 'next/cache'
 
 const categorySchema = z.object({
-  name: z.string().min(1, 'Name is required'),
+  name: z.string().min(1, 'Nome é obrigatório'),
 })
 
 export async function createCategory(formData: FormData) {
@@ -13,22 +13,29 @@ export async function createCategory(formData: FormData) {
     name: formData.get('name'),
   }
 
-  const validated = categorySchema.parse(data)
+  try {
+    const validated = categorySchema.parse(data)
 
-  const existing = await prisma.category.findUnique({
-    where: { name: validated.name },
-  })
+    const existing = await prisma.category.findUnique({
+      where: { name: validated.name },
+    })
 
-  if (existing) {
-    return { error: 'Category already exists' }
+    if (existing) {
+      return { error: 'Categoria já existe' }
+    }
+
+    await prisma.category.create({
+      data: validated,
+    })
+
+    revalidatePath('/products')
+    return { success: true }
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return { error: error.issues[0].message }
+    }
+    return { error: 'Falha ao criar categoria' }
   }
-
-  await prisma.category.create({
-    data: validated,
-  })
-
-  revalidatePath('/products')
-  return { success: true }
 }
 
 export async function getCategories() {

--- a/src/actions/checkout.ts
+++ b/src/actions/checkout.ts
@@ -1,0 +1,101 @@
+'use server'
+
+import { prisma } from '@/lib/prisma'
+import { OrderStatus } from '@prisma/client'
+
+export async function initiateCheckout(userId: string) {
+  const cart = await prisma.cart.findUnique({
+    where: { userId },
+    include: {
+      items: {
+        include: {
+          product: {
+            include: {
+              seller: {
+                include: {
+                  sellerPayment: true,
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  })
+
+  if (!cart || cart.items.length === 0) {
+    return { error: 'Carrinho vazio' }
+  }
+
+  const totalAmount = cart.items.reduce(
+    (sum, item) => sum + item.product.currentPrice * item.quantity,
+    0
+  )
+
+  const sellersWithPayment = new Set<string>()
+  const sellersWithoutPayment = new Set<string>()
+
+  for (const item of cart.items) {
+    if (item.product.seller.sellerPayment?.isActive) {
+      sellersWithPayment.add(item.product.seller.name)
+    } else {
+      sellersWithoutPayment.add(item.product.seller.name)
+    }
+  }
+
+  if (sellersWithoutPayment.size > 0) {
+    const sellerList = Array.from(sellersWithoutPayment).join(', ')
+    return { 
+      error: `Os seguintes vendedores ainda não configuraram pagamento: ${sellerList}. Aguarde até que todos configurem o PIX.`,
+      sellersWithoutPayment: Array.from(sellersWithoutPayment)
+    }
+  }
+
+  const order = await prisma.order.create({
+    data: {
+      buyerId: userId,
+      totalAmount,
+      status: OrderStatus.PENDING,
+      items: {
+        create: cart.items.map((item) => ({
+          productId: item.productId,
+          quantity: item.quantity,
+          price: item.product.currentPrice,
+        })),
+      },
+    },
+    include: {
+      items: true,
+    },
+  })
+
+  const uniqueSellerIds = [...new Set(cart.items.map((item) => item.product.sellerId))]
+  
+  for (const sellerId of uniqueSellerIds) {
+    await prisma.sellerOrder.create({
+      data: {
+        orderId: order.id,
+        sellerId,
+        status: OrderStatus.PENDING,
+      },
+    })
+  }
+
+  await prisma.$transaction([
+    prisma.cartItem.deleteMany({
+      where: { cartId: cart.id },
+    }),
+    ...cart.items.map((item) =>
+      prisma.product.update({
+        where: { id: item.productId },
+        data: {
+          quantity: {
+            decrement: item.quantity,
+          },
+        },
+      })
+    ),
+  ])
+
+  return { success: true, orderId: order.id, totalAmount }
+}

--- a/src/actions/payment.ts
+++ b/src/actions/payment.ts
@@ -1,0 +1,563 @@
+'use server'
+
+import { prisma } from '@/lib/prisma'
+import { revalidatePath } from 'next/cache'
+import { encryptPIXKey, decryptPIXKey, validatePixKey } from '@/lib/encryption'
+import { createPixCharge, getChargeStatus, getMockCharge } from '@/lib/abacatepay'
+import { createPayout, simulateMockPayoutSuccess, getMockPayout } from '@/lib/pagseguro'
+import { OrderStatus, PaymentStatus, PaymentSplitStatus, PayoutStatus, PixKeyType } from '@prisma/client'
+import { z } from 'zod'
+
+const COMMISSION_RATE = 0.10
+
+const SellerPaymentSchema = z.object({
+  cpfCnpj: z.string().min(11).max(14),
+  pixKey: z.string().min(3).max(100),
+  pixKeyType: z.enum(['CPF', 'CNPJ', 'EMAIL', 'TELEFONE']),
+  pixBank: z.string().optional(),
+  termsAccepted: z.boolean().refine(val => val === true, 'Termos devem ser aceitos'),
+})
+
+export async function setupSellerPayment(
+  sellerId: string,
+  data: z.infer<typeof SellerPaymentSchema>
+) {
+  const validation = SellerPaymentSchema.safeParse(data)
+  
+  if (!validation.success) {
+    return { error: validation.error.issues[0].message }
+  }
+
+  if (!validatePixKey(data.pixKey, data.pixKeyType)) {
+    return { error: 'Chave PIX inválida para o tipo selecionado' }
+  }
+
+  const encryptedPixKey = encryptPIXKey(data.pixKey)
+
+  const sellerPayment = await prisma.sellerPayment.upsert({
+    where: { sellerId },
+    create: {
+      sellerId,
+      cpfCnpj: data.cpfCnpj,
+      pixKey: encryptedPixKey,
+      pixKeyType: data.pixKeyType as PixKeyType,
+      pixBank: data.pixBank,
+      termsAccepted: data.termsAccepted,
+      isVerified: false,
+    },
+    update: {
+      cpfCnpj: data.cpfCnpj,
+      pixKey: encryptedPixKey,
+      pixKeyType: data.pixKeyType as PixKeyType,
+      pixBank: data.pixBank,
+      termsAccepted: data.termsAccepted,
+    },
+  })
+
+  revalidatePath('/seller/payment-settings')
+  return { success: true, sellerPayment }
+}
+
+export async function getSellerPayment(sellerId: string) {
+  const payment = await prisma.sellerPayment.findUnique({
+    where: { sellerId },
+  })
+
+  if (!payment) {
+    return null
+  }
+
+  return {
+    ...payment,
+    pixKey: '••••••••••••••••',
+    pixKeyMasked: maskPixKey(decryptPIXKey(payment.pixKey), payment.pixKeyType),
+  }
+}
+
+function maskPixKey(key: string, type: string): string {
+  switch (type) {
+    case 'CPF':
+      return key.replace(/(\d{3})\d{3}(\d{4})/, '$1.***.$2')
+    case 'CNPJ':
+      return key.replace(/(\d{2})\d{3}(\d{4})(\d{2})/, '$1.***.$3-$4')
+    case 'EMAIL':
+      const [local, domain] = key.split('@')
+      return `${local.substring(0, 2)}***@${domain}`
+    case 'TELEFONE':
+      return key.replace(/(\d{2})\d{4}(\d{4})/, '$1****$2')
+    default:
+      return '••••••••'
+  }
+}
+
+export async function hasPaymentSettings(sellerId: string): Promise<boolean> {
+  const payment = await prisma.sellerPayment.findUnique({
+    where: { sellerId },
+  })
+  return !!payment && payment.isActive
+}
+
+export async function getSellerPaymentForPayout(sellerId: string) {
+  const payment = await prisma.sellerPayment.findUnique({
+    where: { sellerId },
+  })
+
+  if (!payment || !payment.isActive) {
+    return null
+  }
+
+  return {
+    ...payment,
+    pixKey: decryptPIXKey(payment.pixKey),
+  }
+}
+
+const CreatePaymentSchema = z.object({
+  orderId: z.string(),
+  customerName: z.string().min(2),
+  customerEmail: z.string().email(),
+  customerDocument: z.string().min(11).max(14),
+})
+
+export async function createPixPayment(
+  userId: string,
+  data: z.infer<typeof CreatePaymentSchema>
+) {
+  const validation = CreatePaymentSchema.safeParse(data)
+  
+  if (!validation.success) {
+    return { error: validation.error.issues[0].message }
+  }
+
+  const order = await prisma.order.findUnique({
+    where: { id: data.orderId },
+    include: {
+      items: {
+        include: {
+          product: {
+            include: {
+              seller: {
+                include: {
+                  sellerPayment: true,
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  })
+
+  if (!order || order.buyerId !== userId) {
+    return { error: 'Pedido não encontrado' }
+  }
+
+  if (order.status !== OrderStatus.PENDING) {
+    return { error: 'Pedido já processado' }
+  }
+
+  const sellersWithPayment = new Set<string>()
+  for (const item of order.items) {
+    if (item.product.seller.sellerPayment?.isActive) {
+      sellersWithPayment.add(item.product.sellerId)
+    }
+  }
+
+  if (sellersWithPayment.size === 0) {
+    return { error: 'Nenhum vendedor possui configuração de pagamento ativa' }
+  }
+
+  const payment = await prisma.payment.create({
+    data: {
+      orderId: order.id,
+      buyerId: userId,
+      amount: order.totalAmount,
+      status: PaymentStatus.PENDING,
+    },
+  })
+
+  const sellerTotals = new Map<string, number>()
+  for (const item of order.items) {
+    const current = sellerTotals.get(item.product.sellerId) || 0
+    sellerTotals.set(item.product.sellerId, current + item.price * item.quantity)
+  }
+
+  for (const [sellerId, grossAmount] of sellerTotals) {
+    const commission = grossAmount * COMMISSION_RATE
+    const netAmount = grossAmount - commission
+
+    await prisma.paymentSplit.create({
+      data: {
+        paymentId: payment.id,
+        sellerId,
+        grossAmount,
+        commission,
+        netAmount,
+        payoutStatus: PaymentSplitStatus.PENDING,
+      },
+    })
+  }
+
+  const products = order.items.map((item) => ({
+    name: `${item.product.name}${item.quantity > 1 ? ` (x${item.quantity})` : ''}`,
+    value: Math.round(item.price * 100),
+    amount: 1,
+  }))
+
+  try {
+    const charge = await createPixCharge({
+      frequency: 'ONE_TIME',
+      methods: ['PIX'],
+      products,
+      customer: {
+        name: data.customerName,
+        email: data.customerEmail,
+        document: data.customerDocument,
+      },
+      returnUrl: `${process.env.NEXTAUTH_URL}/checkout/waiting/${payment.id}`,
+      completionUrl: `${process.env.NEXTAUTH_URL}/checkout/waiting/${payment.id}`,
+    })
+
+    await prisma.payment.update({
+      where: { id: payment.id },
+      data: {
+        abacatePayId: charge.id,
+        status: charge.pix ? PaymentStatus.WAITING : PaymentStatus.PENDING,
+        pixQrCode: charge.pix?.qrCode,
+        pixCopyPaste: charge.pix?.copyPaste,
+        paymentUrl: charge.pix ? `${process.env.NEXTAUTH_URL}/checkout/waiting/${payment.id}` : null,
+      },
+    })
+
+    revalidatePath('/cart')
+    revalidatePath('/orders')
+    
+    return {
+      success: true,
+      paymentId: payment.id,
+      pixQrCode: charge.pix?.qrCode,
+      pixCopyPaste: charge.pix?.copyPaste,
+    }
+  } catch (error) {
+    await prisma.$transaction([
+      prisma.paymentSplit.deleteMany({ where: { paymentId: payment.id } }),
+      prisma.payment.delete({ where: { id: payment.id } }),
+    ])
+    
+    console.error('Payment creation error:', error)
+    return { error: 'Erro ao criar pagamento. Tente novamente.' }
+  }
+}
+
+export async function checkPaymentStatus(paymentId: string) {
+  const payment = await prisma.payment.findUnique({
+    where: { id: paymentId },
+    include: {
+      order: true,
+    },
+  })
+
+  if (!payment) {
+    return { error: 'Pagamento não encontrado' }
+  }
+
+  if (payment.status === PaymentStatus.CONFIRMED) {
+    return {
+      success: true,
+      status: payment.status,
+      orderId: payment.orderId,
+    }
+  }
+
+  if (!payment.abacatePayId) {
+    return { error: 'ID de pagamento não encontrado' }
+  }
+
+  try {
+    const charge = await getChargeStatus(payment.abacatePayId)
+
+    let newStatus: PaymentStatus = payment.status as PaymentStatus
+    if (charge.status === 'CONFIRMED') {
+      newStatus = PaymentStatus.CONFIRMED
+    } else if (charge.status === 'FAILED' || charge.status === 'CANCELED') {
+      newStatus = PaymentStatus.FAILED
+    }
+
+    if (newStatus !== payment.status) {
+      await prisma.payment.update({
+        where: { id: paymentId },
+        data: {
+          status: newStatus,
+          paidAt: newStatus === PaymentStatus.CONFIRMED ? new Date() : null,
+        },
+      })
+
+      if (newStatus === PaymentStatus.CONFIRMED) {
+        await processPaymentSplit(paymentId)
+        
+        await prisma.order.update({
+          where: { id: payment.orderId },
+          data: { status: OrderStatus.CONFIRMED },
+        })
+      } else if (newStatus === PaymentStatus.FAILED) {
+        await prisma.order.update({
+          where: { id: payment.orderId },
+          data: { status: OrderStatus.CANCELLED },
+        })
+      }
+
+      revalidatePath('/orders')
+      revalidatePath(`/checkout/waiting/${paymentId}`)
+    }
+
+    return {
+      success: true,
+      status: newStatus,
+      orderId: payment.orderId,
+    }
+  } catch (error) {
+    console.error('Payment status check error:', error)
+    return { error: 'Erro ao verificar status do pagamento' }
+  }
+}
+
+export async function getPaymentById(paymentId: string) {
+  return prisma.payment.findUnique({
+    where: { id: paymentId },
+    include: {
+      order: {
+        include: {
+          items: {
+            include: {
+              product: {
+                include: {
+                  seller: true,
+                },
+              },
+            },
+          },
+        },
+      },
+      splits: {
+        include: {
+          payout: true,
+        },
+      },
+    },
+  })
+}
+
+export async function processPaymentSplit(paymentId: string) {
+  const payment = await prisma.payment.findUnique({
+    where: { id: paymentId },
+    include: {
+      splits: true,
+    },
+  })
+
+  if (!payment || payment.status !== PaymentStatus.CONFIRMED) {
+    return { error: 'Pagamento não confirmado' }
+  }
+
+  for (const split of payment.splits) {
+    if (split.payoutStatus !== PaymentSplitStatus.PENDING) {
+      continue
+    }
+
+    const sellerPayment = await getSellerPaymentForPayout(split.sellerId)
+    
+    if (!sellerPayment) {
+      console.log(`No payment settings for seller ${split.sellerId}, skipping payout`)
+      continue
+    }
+
+    await prisma.paymentSplit.update({
+      where: { id: split.id },
+      data: { payoutStatus: PaymentSplitStatus.PROCESSING },
+    })
+
+    try {
+      const payout = await createPayout({
+        pixKey: sellerPayment.pixKey,
+        pixKeyType: sellerPayment.pixKeyType,
+        amount: split.netAmount,
+        referenceId: split.id,
+        description: `Pagamento pedido ${payment.orderId}`,
+      })
+
+      await prisma.payout.create({
+        data: {
+          sellerId: split.sellerId,
+          paymentSplitId: split.id,
+          amount: split.netAmount,
+          pagseguroId: payout.id,
+          status: PayoutStatus.PROCESSING,
+        },
+      })
+
+      await prisma.paymentSplit.update({
+        where: { id: split.id },
+        data: {
+          payoutStatus: PaymentSplitStatus.SENT,
+        },
+      })
+
+      revalidatePath('/seller/balance')
+      revalidatePath('/seller/payouts')
+    } catch (error) {
+      console.error(`Payout error for split ${split.id}:`, error)
+      
+      await prisma.paymentSplit.update({
+        where: { id: split.id },
+        data: { payoutStatus: PaymentSplitStatus.FAILED },
+      })
+    }
+  }
+
+  return { success: true }
+}
+
+export async function getSellerBalance(sellerId: string) {
+  const splits = await prisma.paymentSplit.findMany({
+    where: {
+      sellerId,
+    },
+    include: {
+      payment: {
+        include: {
+          order: true,
+        },
+      },
+    },
+    orderBy: { createdAt: 'desc' },
+  })
+
+  let pending = 0
+  let inTransit = 0
+  let available = 0
+  let totalPaid = 0
+
+  for (const split of splits) {
+    if (split.payoutStatus === PaymentSplitStatus.PENDING) {
+      pending += split.netAmount
+    } else if (split.payoutStatus === PaymentSplitStatus.SENT || 
+               split.payoutStatus === PaymentSplitStatus.PROCESSING) {
+      inTransit += split.netAmount
+    } else if (split.payoutStatus === PaymentSplitStatus.SUCCESS) {
+      available += split.netAmount
+      totalPaid += split.netAmount
+    }
+  }
+
+  return {
+    pending,
+    inTransit,
+    available,
+    totalPaid,
+    transactionCount: splits.length,
+  }
+}
+
+export async function getPayoutHistory(sellerId: string, limit = 20) {
+  const payouts = await prisma.payout.findMany({
+    where: { sellerId },
+    include: {
+      paymentSplit: {
+        include: {
+          payment: {
+            include: {
+              order: true,
+            },
+          },
+        },
+      },
+    },
+    orderBy: { createdAt: 'desc' },
+    take: limit,
+  })
+
+  return payouts
+}
+
+export async function retryPayout(payoutId: string) {
+  const payout = await prisma.payout.findUnique({
+    where: { id: payoutId },
+    include: {
+      paymentSplit: true,
+    },
+  })
+
+  if (!payout) {
+    return { error: 'Repasse não encontrado' }
+  }
+
+  if (payout.status === PayoutStatus.SUCCESS) {
+    return { error: 'Repasse já confirmado' }
+  }
+
+  const sellerPayment = await getSellerPaymentForPayout(payout.sellerId)
+  
+  if (!sellerPayment) {
+    return { error: 'Configuração de pagamento não encontrada' }
+  }
+
+  try {
+    const result = await createPayout({
+      pixKey: sellerPayment.pixKey,
+      pixKeyType: sellerPayment.pixKeyType,
+      amount: payout.amount,
+      referenceId: payout.paymentSplitId,
+      description: `Retry - Pagamento ${payout.paymentSplitId}`,
+    })
+
+    await prisma.payout.update({
+      where: { id: payoutId },
+      data: {
+        pagseguroId: result.id,
+        status: PayoutStatus.PROCESSING,
+        errorMessage: null,
+      },
+    })
+
+    revalidatePath('/seller/payouts')
+    return { success: true }
+  } catch (error) {
+    await prisma.payout.update({
+      where: { id: payoutId },
+      data: {
+        status: PayoutStatus.FAILED,
+        errorMessage: error instanceof Error ? error.message : 'Erro desconhecido',
+      },
+    })
+    
+    return { error: 'Erro ao tentar novamente. Entre em contato com o suporte.' }
+  }
+}
+
+export async function getAllPayouts(status?: string) {
+  const where: Record<string, unknown> = {}
+  
+  if (status && status !== 'all') {
+    where.status = status.toUpperCase()
+  }
+
+  return prisma.payout.findMany({
+    where,
+    include: {
+      seller: {
+        select: { name: true, email: true },
+      },
+      paymentSplit: {
+        include: {
+          payment: {
+            include: {
+              order: true,
+            },
+          },
+        },
+      },
+    },
+    orderBy: { createdAt: 'desc' },
+    take: 100,
+  })
+}

--- a/src/actions/product.ts
+++ b/src/actions/product.ts
@@ -57,27 +57,34 @@ export async function updateProduct(productId: string, sellerId: string, formDat
     imageUrl: formData.get('imageUrl') || undefined,
   }
 
-  const validated = productSchema.parse(data)
+  try {
+    const validated = productSchema.parse(data)
 
-  const product = await prisma.product.findUnique({
-    where: { id: productId },
-  })
+    const product = await prisma.product.findUnique({
+      where: { id: productId },
+    })
 
-  if (!product || product.sellerId !== sellerId) {
-    return { error: 'Não autorizado a atualizar este produto' }
+    if (!product || product.sellerId !== sellerId) {
+      return { error: 'Não autorizado a atualizar este produto' }
+    }
+
+    await prisma.product.update({
+      where: { id: productId },
+      data: {
+        ...validated,
+        imageUrl: validated.imageUrl || null,
+      },
+    })
+
+    revalidatePath('/products')
+    revalidatePath(`/products/${productId}`)
+    return { success: true }
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return { error: error.issues[0].message }
+    }
+    return { error: 'Falha ao atualizar produto' }
   }
-
-  await prisma.product.update({
-    where: { id: productId },
-    data: {
-      ...validated,
-      imageUrl: validated.imageUrl || null,
-    },
-  })
-
-  revalidatePath('/products')
-  revalidatePath(`/products/${productId}`)
-  return { success: true }
 }
 
 export async function deleteProduct(productId: string, sellerId: string) {

--- a/src/app/api/webhooks/abacatepay/route.ts
+++ b/src/app/api/webhooks/abacatepay/route.ts
@@ -1,0 +1,86 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/prisma'
+import { validateWebhookSignature } from '@/lib/abacatepay'
+import { processPaymentSplit } from '@/actions/payment'
+import { OrderStatus, PaymentStatus } from '@prisma/client'
+
+export async function POST(request: NextRequest) {
+  try {
+    const signature = request.headers.get('x-abacate-signature')
+    const body = await request.text()
+
+    if (!signature) {
+      console.error('[Webhook] Missing signature')
+      return NextResponse.json({ error: 'Missing signature' }, { status: 401 })
+    }
+
+    const isValid = validateWebhookSignature(body, signature)
+    
+    if (!isValid && process.env.MOCK_PAYMENTS !== 'true') {
+      console.error('[Webhook] Invalid signature')
+      return NextResponse.json({ error: 'Invalid signature' }, { status: 401 })
+    }
+
+    const payload = JSON.parse(body)
+    console.log('[Webhook] AbacatePay payload:', payload)
+
+    const { id: chargeId, status, paidAt } = payload
+
+    if (!chargeId || !status) {
+      return NextResponse.json({ error: 'Invalid payload' }, { status: 400 })
+    }
+
+    const payment = await prisma.payment.findFirst({
+      where: { abacatePayId: chargeId },
+      include: { order: true },
+    })
+
+    if (!payment) {
+      console.error('[Webhook] Payment not found for charge:', chargeId)
+      return NextResponse.json({ error: 'Payment not found' }, { status: 404 })
+    }
+
+    let newPaymentStatus: PaymentStatus | null = null
+
+    if (status === 'CONFIRMED' || status === 'PAID') {
+      newPaymentStatus = PaymentStatus.CONFIRMED
+    } else if (status === 'FAILED' || status === 'CANCELED' || status === 'EXPIRED') {
+      newPaymentStatus = PaymentStatus.FAILED
+    }
+
+    if (newPaymentStatus && newPaymentStatus !== payment.status) {
+      await prisma.payment.update({
+        where: { id: payment.id },
+        data: {
+          status: newPaymentStatus,
+          paidAt: newPaymentStatus === PaymentStatus.CONFIRMED ? new Date(paidAt) : null,
+        },
+      })
+
+      if (newPaymentStatus === PaymentStatus.CONFIRMED) {
+        await prisma.order.update({
+          where: { id: payment.orderId },
+          data: { status: OrderStatus.CONFIRMED },
+        })
+
+        await processPaymentSplit(payment.id)
+      } else if (newPaymentStatus === PaymentStatus.FAILED) {
+        await prisma.order.update({
+          where: { id: payment.orderId },
+          data: { status: OrderStatus.CANCELLED },
+        })
+      }
+
+      console.log(`[Webhook] Payment ${payment.id} updated to ${newPaymentStatus}`)
+    }
+
+    return NextResponse.json({ success: true })
+  } catch (error) {
+    console.error('[Webhook] Error processing AbacatePay webhook:', error)
+    return NextResponse.json({ error: 'Internal error' }, { status: 500 })
+  }
+}
+
+export async function GET() {
+  return NextResponse.json({ status: 'ok', message: 'AbacatePay webhook endpoint' })
+}

--- a/src/app/api/webhooks/pagseguro/route.ts
+++ b/src/app/api/webhooks/pagseguro/route.ts
@@ -1,0 +1,85 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/prisma'
+import { validateWebhookSignature } from '@/lib/pagseguro'
+import { PayoutStatus, PaymentSplitStatus } from '@prisma/client'
+
+export async function POST(request: NextRequest) {
+  try {
+    const signature = request.headers.get('x-pagseguro-signature')
+    const body = await request.text()
+
+    if (!signature) {
+      console.error('[Webhook] Missing PagSeguro signature')
+      return NextResponse.json({ error: 'Missing signature' }, { status: 401 })
+    }
+
+    const isValid = validateWebhookSignature(body, signature)
+    
+    if (!isValid && process.env.MOCK_PAYMENTS !== 'true') {
+      console.error('[Webhook] Invalid PagSeguro signature')
+      return NextResponse.json({ error: 'Invalid signature' }, { status: 401 })
+    }
+
+    const payload = JSON.parse(body)
+    console.log('[Webhook] PagSeguro payload:', payload)
+
+    const { id: payoutId, status, errorMessage } = payload
+
+    if (!payoutId || !status) {
+      return NextResponse.json({ error: 'Invalid payload' }, { status: 400 })
+    }
+
+    const payout = await prisma.payout.findFirst({
+      where: { pagseguroId: payoutId },
+    })
+
+    if (!payout) {
+      console.error('[Webhook] Payout not found for ID:', payoutId)
+      return NextResponse.json({ error: 'Payout not found' }, { status: 404 })
+    }
+
+    let newPayoutStatus: PayoutStatus | null = null
+    let newSplitStatus: PaymentSplitStatus | null = null
+
+    if (status === 'SUCCESS' || status === 'COMPLETED') {
+      newPayoutStatus = PayoutStatus.SUCCESS
+      newSplitStatus = PaymentSplitStatus.SUCCESS
+    } else if (status === 'PROCESSING' || status === 'PENDING') {
+      newPayoutStatus = PayoutStatus.PROCESSING
+      newSplitStatus = PaymentSplitStatus.PROCESSING
+    } else if (status === 'FAILED' || status === 'CANCELED' || status === 'REVERSED') {
+      newPayoutStatus = PayoutStatus.FAILED
+      newSplitStatus = PaymentSplitStatus.FAILED
+    }
+
+    if (newPayoutStatus) {
+      await prisma.payout.update({
+        where: { id: payout.id },
+        data: {
+          status: newPayoutStatus,
+          errorMessage: errorMessage || null,
+          processedAt: newPayoutStatus === PayoutStatus.SUCCESS ? new Date() : null,
+        },
+      })
+
+      await prisma.paymentSplit.update({
+        where: { id: payout.paymentSplitId },
+        data: {
+          payoutStatus: newSplitStatus,
+          paidAt: newSplitStatus === PaymentSplitStatus.SUCCESS ? new Date() : null,
+        },
+      })
+
+      console.log(`[Webhook] Payout ${payout.id} updated to ${newPayoutStatus}`)
+    }
+
+    return NextResponse.json({ success: true })
+  } catch (error) {
+    console.error('[Webhook] Error processing PagSeguro webhook:', error)
+    return NextResponse.json({ error: 'Internal error' }, { status: 500 })
+  }
+}
+
+export async function GET() {
+  return NextResponse.json({ status: 'ok', message: 'PagSeguro webhook endpoint' })
+}

--- a/src/app/cart/CartClient.tsx
+++ b/src/app/cart/CartClient.tsx
@@ -4,16 +4,14 @@ import { useState } from 'react'
 import Link from 'next/link'
 import { useRouter } from 'next/navigation'
 import { updateCartItemQuantity, removeFromCart } from '@/actions/cart'
-import { createOrder } from '@/actions/order'
 import { Trash2, Minus, Plus, ShoppingBag, ArrowRight } from 'lucide-react'
 import { getMessage } from '@/lib/messages'
 
 import type { CartWithItems, CartItemWithProduct } from '@/types/database'
 
-export function CartClient({ cart, userId }: { cart: CartWithItems; userId: string }) {
+export function CartClient({ cart }: { cart: CartWithItems }) {
   const router = useRouter()
   const [cartData, setCartData] = useState(cart)
-  const [checkingOut, setCheckingOut] = useState(false)
 
   async function handleUpdateQuantity(itemId: string, quantity: number) {
     await updateCartItemQuantity(itemId, quantity)
@@ -35,19 +33,7 @@ export function CartClient({ cart, userId }: { cart: CartWithItems; userId: stri
   }
 
   async function handleCheckout() {
-    setCheckingOut(true)
-    const items = cartData.items.map((item: CartItemWithProduct) => ({
-      productId: item.productId,
-      quantity: item.quantity,
-      price: item.product.currentPrice,
-    }))
-
-    const result = await createOrder(userId, items)
-    
-    if (result.success) {
-      router.push('/orders')
-    }
-    setCheckingOut(false)
+    router.push('/checkout')
   }
 
   const total = cartData?.items.reduce(
@@ -147,11 +133,10 @@ export function CartClient({ cart, userId }: { cart: CartWithItems; userId: stri
               </div>
               <button
                 onClick={handleCheckout}
-                disabled={checkingOut}
-                className="w-full bg-primary text-primary-foreground py-3 rounded-lg hover:bg-primary/90 transition-colors disabled:opacity-50 flex items-center justify-center gap-2 font-medium"
+                className="w-full bg-primary text-primary-foreground py-3 rounded-lg hover:bg-primary/90 transition-colors flex items-center justify-center gap-2 font-medium"
               >
-                {checkingOut ? 'Processando...' : getMessage('cart.checkout')}
-                {!checkingOut && <ArrowRight className="w-5 h-5" />}
+                {getMessage('cart.checkout')}
+                <ArrowRight className="w-5 h-5" />
               </button>
             </div>
           </div>

--- a/src/app/cart/CartClient.tsx
+++ b/src/app/cart/CartClient.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useState } from 'react'
+import Link from 'next/link'
 import { useRouter } from 'next/navigation'
 import { updateCartItemQuantity, removeFromCart } from '@/actions/cart'
 import { createOrder } from '@/actions/order'
@@ -62,12 +63,12 @@ export function CartClient({ cart, userId }: { cart: CartWithItems; userId: stri
         <div className="text-center py-16 bg-card rounded-xl border">
           <ShoppingBag className="w-16 h-16 mx-auto mb-4 text-muted-foreground" />
           <p className="text-muted-foreground text-lg mb-6">{getMessage('cart.empty')}</p>
-          <a
+          <Link
             href="/products"
             className="inline-flex items-center gap-2 text-primary hover:underline"
           >
             Ver produtos <ArrowRight className="w-4 h-4" />
-          </a>
+          </Link>
         </div>
       ) : (
         <div className="grid lg:grid-cols-3 gap-8">

--- a/src/app/cart/page.tsx
+++ b/src/app/cart/page.tsx
@@ -12,5 +12,5 @@ export default async function CartPage() {
 
   const cart = await getCart(session.user.id)
 
-  return <CartClient cart={cart} userId={session.user.id} />
+  return <CartClient cart={cart} />
 }

--- a/src/app/checkout/CheckoutClient.tsx
+++ b/src/app/checkout/CheckoutClient.tsx
@@ -1,0 +1,195 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+import { useRouter } from 'next/navigation'
+import { initiateCheckout } from '@/actions/checkout'
+import { createPixPayment, checkPaymentStatus } from '@/actions/payment'
+import { getMessage } from '@/lib/messages'
+import { AlertCircle, Loader2, CheckCircle } from 'lucide-react'
+import type { CartWithItems } from '@/types/database'
+
+interface CheckoutClientProps {
+  cart: CartWithItems
+  userId: string
+  userEmail: string
+  userName: string
+}
+
+export function CheckoutClient({ cart, userId, userEmail, userName }: CheckoutClientProps) {
+  const router = useRouter()
+  const [step, setStep] = useState<'review' | 'processing' | 'success'>('review')
+  const [error, setError] = useState<string | null>(null)
+  const [customerDocument, setCustomerDocument] = useState('')
+  const [orderId, setOrderId] = useState<string | null>(null)
+
+  const total = cart?.items.reduce(
+    (sum, item) => sum + item.product.currentPrice * item.quantity,
+    0
+  ) || 0
+
+  useEffect(() => {
+    if (step === 'success' && orderId) {
+      router.push('/orders')
+    }
+  }, [step, orderId, router])
+
+  async function handleInitiateCheckout() {
+    setError(null)
+    setStep('processing')
+
+    const result = await initiateCheckout(userId)
+    
+    if (result.error) {
+      setError(result.error)
+      setStep('review')
+      return
+    }
+
+    setOrderId(result.orderId!)
+
+    const paymentResult = await createPixPayment(userId, {
+      orderId: result.orderId!,
+      customerName: userName,
+      customerEmail: userEmail,
+      customerDocument: customerDocument.replace(/\D/g, ''),
+    })
+
+    if (paymentResult.error) {
+      setError(paymentResult.error)
+      setStep('review')
+      return
+    }
+
+    const isMock = process.env.NEXT_PUBLIC_MOCK_PAYMENTS === 'true'
+    
+    if (isMock) {
+      await checkPaymentStatus(paymentResult.paymentId!)
+    }
+
+    setStep('success')
+  }
+
+  if (step === 'success') {
+    return (
+      <div className="text-center py-16">
+        <CheckCircle className="w-20 h-20 text-green-500 mx-auto mb-4" />
+        <h1 className="text-2xl font-bold text-green-600 mb-2">Pedido Realizado com Sucesso!</h1>
+        <p className="text-muted-foreground">Redirecionando para seus pedidos...</p>
+      </div>
+    )
+  }
+
+  return (
+    <div>
+      <h1 className="text-3xl font-bold mb-8">{getMessage('checkout.title')}</h1>
+
+      {error && (
+        <div className="mb-6 p-4 bg-red-50 border border-red-200 rounded-lg flex items-center gap-3">
+          <AlertCircle className="w-5 h-5 text-red-500 flex-shrink-0" />
+          <p className="text-red-700">{error}</p>
+        </div>
+      )}
+
+      <div className="grid lg:grid-cols-3 gap-8">
+        <div className="lg:col-span-2 space-y-4">
+          <div className="bg-card rounded-xl border p-6">
+            <h2 className="text-lg font-semibold mb-4">{getMessage('checkout.review')}</h2>
+            
+            {cart?.items.map((item) => (
+              <div key={item.id} className="flex gap-4 py-4 border-b last:border-0">
+                <div className="w-20 h-20 rounded-lg overflow-hidden bg-muted flex-shrink-0">
+                  {item.product.imageUrl ? (
+                    <img
+                      src={item.product.imageUrl}
+                      alt={item.product.name}
+                      className="object-cover w-full h-full"
+                    />
+                  ) : (
+                    <div className="w-full h-full flex items-center justify-center">
+                      <span className="text-xs text-muted-foreground">Sem Imagem</span>
+                    </div>
+                  )}
+                </div>
+                <div className="flex-1">
+                  <h3 className="font-medium">{item.product.name}</h3>
+                  <p className="text-sm text-muted-foreground">
+                    {item.product.seller.name}
+                  </p>
+                  <p className="text-sm">
+                    Qtd: {item.quantity} x R$ {item.product.currentPrice.toFixed(2).replace('.', ',')}
+                  </p>
+                </div>
+                <div className="font-medium">
+                  R$ {(item.product.currentPrice * item.quantity).toFixed(2).replace('.', ',')}
+                </div>
+              </div>
+            ))}
+          </div>
+
+          <div className="bg-card rounded-xl border p-6">
+            <h2 className="text-lg font-semibold mb-4">Dados para Pagamento</h2>
+            <div>
+              <label className="block text-sm font-medium mb-2">
+                CPF do comprador
+              </label>
+              <input
+                type="text"
+                value={customerDocument}
+                onChange={(e) => setCustomerDocument(e.target.value)}
+                placeholder="000.000.000-00"
+                className="w-full px-4 py-2 rounded-lg border bg-background focus:outline-none focus:ring-2 focus:ring-primary"
+              />
+              <p className="text-sm text-muted-foreground mt-1">
+                Necessário para emissão de nota fiscal
+              </p>
+            </div>
+          </div>
+        </div>
+
+        <div className="lg:col-span-1">
+          <div className="bg-card rounded-xl border p-6 sticky top-4">
+            <h2 className="text-lg font-semibold mb-4">{getMessage('cart.summary') || 'Resumo do Pedido'}</h2>
+            
+            <div className="space-y-3 mb-4">
+              <div className="flex justify-between">
+                <span className="text-muted-foreground">{getMessage('cart.subtotal')}</span>
+                <span>R$ {total.toFixed(2).replace('.', ',')}</span>
+              </div>
+              <div className="flex justify-between">
+                <span className="text-muted-foreground">Frete</span>
+                <span>A combinar</span>
+              </div>
+              <div className="border-t pt-3 flex justify-between text-lg font-bold">
+                <span>{getMessage('cart.total')}</span>
+                <span className="text-primary">R$ {total.toFixed(2).replace('.', ',')}</span>
+              </div>
+            </div>
+
+            <div className="mb-4 p-3 bg-muted rounded-lg">
+              <p className="text-sm font-medium">Método de pagamento</p>
+              <p className="text-sm text-muted-foreground">PIX (instantâneo)</p>
+              {process.env.NEXT_PUBLIC_MOCK_PAYMENTS === 'true' && (
+                <p className="text-xs text-blue-600 mt-1">Modo teste ativo</p>
+              )}
+            </div>
+
+            <button
+              onClick={handleInitiateCheckout}
+              disabled={step === 'processing' || !customerDocument}
+              className="w-full bg-primary text-primary-foreground py-3 rounded-lg hover:bg-primary/90 transition-colors disabled:opacity-50 flex items-center justify-center gap-2 font-medium"
+            >
+              {step === 'processing' ? (
+                <>
+                  <Loader2 className="w-5 h-5 animate-spin" />
+                  Processando...
+                </>
+              ) : (
+                <>Pagar com PIX</>
+              )}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/app/checkout/page.tsx
+++ b/src/app/checkout/page.tsx
@@ -1,0 +1,45 @@
+import { auth } from '@/lib/auth'
+import { redirect } from 'next/navigation'
+import { prisma } from '@/lib/prisma'
+import { CheckoutClient } from './CheckoutClient'
+
+export default async function CheckoutPage() {
+  const session = await auth()
+  
+  if (!session?.user) {
+    redirect('/login')
+  }
+
+  const cart = await prisma.cart.findUnique({
+    where: { userId: session.user.id },
+    include: {
+      items: {
+        include: {
+          product: {
+            include: {
+              seller: true,
+            },
+          },
+        },
+      },
+    },
+  })
+
+  if (!cart || cart.items.length === 0) {
+    redirect('/cart')
+  }
+
+  const user = await prisma.user.findUnique({
+    where: { id: session.user.id },
+    select: { name: true, email: true },
+  })
+
+  return (
+    <CheckoutClient
+      cart={cart}
+      userId={session.user.id}
+      userEmail={user?.email || ''}
+      userName={user?.name || ''}
+    />
+  )
+}

--- a/src/app/checkout/waiting/PaymentWaitingClient.tsx
+++ b/src/app/checkout/waiting/PaymentWaitingClient.tsx
@@ -1,0 +1,152 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+import { useRouter } from 'next/navigation'
+import { checkPaymentStatus } from '@/actions/payment'
+import { QrCode, Copy, CheckCircle, Loader2, Timer } from 'lucide-react'
+
+interface PaymentWaitingClientProps {
+  paymentId: string
+  pixQrCode: string
+  pixCopyPaste: string
+  amount: number
+}
+
+export function PaymentWaitingClient({ 
+  paymentId, 
+  pixQrCode, 
+  pixCopyPaste,
+  amount 
+}: PaymentWaitingClientProps) {
+  const router = useRouter()
+  const [status, setStatus] = useState<'waiting' | 'confirmed' | 'failed'>('waiting')
+  const [loading, setLoading] = useState(false)
+  const [copied, setCopied] = useState(false)
+  const [timeLeft, setTimeLeft] = useState(300)
+
+  useEffect(() => {
+    const interval = setInterval(async () => {
+      setLoading(true)
+      const result = await checkPaymentStatus(paymentId)
+      setLoading(false)
+
+      if (result.success) {
+        if (result.status === 'CONFIRMED') {
+          setStatus('confirmed')
+          setTimeout(() => {
+            router.push('/orders')
+          }, 2000)
+        }
+      }
+    }, 5000)
+
+    return () => clearInterval(interval)
+  }, [paymentId, router])
+
+  useEffect(() => {
+    const timer = setInterval(() => {
+      setTimeLeft((prev) => {
+        if (prev <= 1) {
+          clearInterval(timer)
+          return 0
+        }
+        return prev - 1
+      })
+    }, 1000)
+
+    return () => clearInterval(timer)
+  }, [])
+
+  function copyToClipboard() {
+    navigator.clipboard.writeText(pixCopyPaste)
+    setCopied(true)
+    setTimeout(() => setCopied(false), 2000)
+  }
+
+  const formatTime = (seconds: number) => {
+    const mins = Math.floor(seconds / 60)
+    const secs = seconds % 60
+    return `${mins}:${secs.toString().padStart(2, '0')}`
+  }
+
+  if (status === 'confirmed') {
+    return (
+      <div className="text-center py-16">
+        <CheckCircle className="w-20 h-20 text-green-500 mx-auto mb-4" />
+        <h1 className="text-2xl font-bold text-green-600 mb-2">Pagamento Confirmado!</h1>
+        <p className="text-muted-foreground">Redirecionando para seus pedidos...</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="max-w-md mx-auto py-8 px-4">
+      <h1 className="text-2xl font-bold text-center mb-2">Pague com PIX</h1>
+      <p className="text-center text-muted-foreground mb-6">
+        Valor: <span className="font-bold text-lg">R$ {amount.toFixed(2).replace('.', ',')}</span>
+      </p>
+
+      <div className="bg-card rounded-xl border p-6 mb-6">
+        <div className="flex items-center justify-between mb-4">
+          <span className="text-sm text-muted-foreground">QR Code expira em</span>
+          <span className="flex items-center gap-2 font-medium">
+            <Timer className="w-4 h-4" />
+            {formatTime(timeLeft)}
+          </span>
+        </div>
+
+        <div className="bg-white p-4 rounded-lg mb-4">
+          {pixQrCode ? (
+            <img 
+              src={`https://api.qrserver.com/v1/create-qr-code/?size=200x200&data=${encodeURIComponent(pixQrCode)}`}
+              alt="QR Code PIX"
+              className="w-48 h-48 mx-auto"
+            />
+          ) : (
+            <div className="w-48 h-48 mx-auto bg-muted flex items-center justify-center">
+              <QrCode className="w-16 h-16 text-muted-foreground" />
+            </div>
+          )}
+        </div>
+
+        <div className="space-y-2">
+          <p className="text-sm text-muted-foreground text-center">Ou copie o código:</p>
+          <div className="flex gap-2">
+            <input
+              type="text"
+              value={pixCopyPaste.slice(0, 50) + '...'}
+              readOnly
+              className="flex-1 px-3 py-2 text-sm bg-muted rounded-lg border"
+            />
+            <button
+              onClick={copyToClipboard}
+              className="px-4 py-2 bg-primary text-primary-foreground rounded-lg hover:bg-primary/90 flex items-center gap-2"
+            >
+              {copied ? <CheckCircle className="w-4 h-4" /> : <Copy className="w-4 h-4" />}
+              {copied ? 'Copiado!' : 'Copiar'}
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <div className="text-center space-y-2">
+        <div className="flex items-center justify-center gap-2 text-muted-foreground">
+          <Loader2 className={`w-4 h-4 ${loading ? 'animate-spin' : ''}`} />
+          <span className="text-sm">
+            {loading ? 'Verificando pagamento...' : 'Aguardando pagamento...'}
+          </span>
+        </div>
+        <p className="text-xs text-muted-foreground">
+          O pagamento será confirmado automaticamente em alguns segundos
+        </p>
+      </div>
+
+      <button
+        onClick={() => router.push('/cart')}
+        className="w-full mt-6 py-3 text-primary hover:underline"
+      >
+        Cancelar e voltar ao carrinho
+      </button>
+    </div>
+  )
+}

--- a/src/app/checkout/waiting/[id]/page.tsx
+++ b/src/app/checkout/waiting/[id]/page.tsx
@@ -1,0 +1,38 @@
+import { auth } from '@/lib/auth'
+import { redirect } from 'next/navigation'
+import { prisma } from '@/lib/prisma'
+import { PaymentWaitingClient } from '../PaymentWaitingClient'
+
+interface Props {
+  params: Promise<{ id: string }>
+}
+
+export default async function CheckoutWaitingPage({ params }: Props) {
+  const session = await auth()
+  
+  if (!session?.user) {
+    redirect('/login')
+  }
+
+  const { id: paymentId } = await params
+
+  const payment = await prisma.payment.findUnique({
+    where: { id: paymentId },
+    include: {
+      order: true,
+    },
+  })
+
+  if (!payment || payment.buyerId !== session.user.id) {
+    redirect('/cart')
+  }
+
+  return (
+    <PaymentWaitingClient
+      paymentId={payment.id}
+      pixQrCode={payment.pixQrCode || ''}
+      pixCopyPaste={payment.pixCopyPaste || ''}
+      amount={payment.amount}
+    />
+  )
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -53,8 +53,8 @@
   --color-warm-yellow: var(--warm-yellow);
   --color-warm-yellow-foreground: var(--warm-yellow-foreground);
   --color-sand: var(--sand);
-  --font-heading: 'Poppins', sans-serif;
-  --font-body: 'Inter', sans-serif;
+  --font-heading: var(--font-poppins), sans-serif;
+  --font-body: var(--font-inter), sans-serif;
   --radius-sm: calc(var(--radius) - 0.25rem);
   --radius-md: calc(var(--radius));
   --radius-lg: calc(var(--radius) + 0.25rem);

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,7 +1,15 @@
 import type { Metadata } from "next";
+import { Inter, Poppins } from "next/font/google";
 import "./globals.css";
 import Navbar from "@/components/Navbar";
 import { getMessage } from "@/lib/messages";
+
+const inter = Inter({ subsets: ["latin"], variable: "--font-inter" });
+const poppins = Poppins({ 
+  subsets: ["latin"], 
+  weight: ["400", "500", "600", "700", "800"],
+  variable: "--font-poppins" 
+});
 
 export const metadata: Metadata = {
   title: `${getMessage('brand.name')} - ${getMessage('brand.slogan')}`,
@@ -15,12 +23,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="pt-br">
-      <head>
-        <link rel="preconnect" href="https://fonts.googleapis.com" />
-        <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
-        <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600&family=Poppins:wght@400;500;600;700;800&display=swap" rel="stylesheet" />
-      </head>
-      <body className="font-body min-h-screen flex flex-col">
+      <body className={`${inter.variable} ${poppins.variable} font-body min-h-screen flex flex-col`}>
         <Navbar />
         <main className="flex-1 container mx-auto px-4 py-8">
           {children}

--- a/src/app/orders/page.tsx
+++ b/src/app/orders/page.tsx
@@ -18,6 +18,10 @@ export default async function OrdersPage() {
   const statusConfig = {
     PENDING: { icon: Clock, color: 'text-yellow-600 bg-yellow-100', label: 'Pendente' },
     CONFIRMED: { icon: CheckCircle, color: 'text-green-600 bg-green-100', label: 'Confirmado' },
+    PREPARING: { icon: Clock, color: 'text-blue-600 bg-blue-100', label: 'Preparando' },
+    READY: { icon: CheckCircle, color: 'text-purple-600 bg-purple-100', label: 'Pronto' },
+    SHIPPED: { icon: Package, color: 'text-indigo-600 bg-indigo-100', label: 'Enviado' },
+    COMPLETED: { icon: CheckCircle, color: 'text-green-600 bg-green-100', label: 'Concluído' },
     CANCELLED: { icon: XCircle, color: 'text-red-600 bg-red-100', label: 'Cancelado' },
   }
 
@@ -39,7 +43,7 @@ export default async function OrdersPage() {
       ) : (
         <div className="space-y-6">
           {orders.map((order) => {
-            const status = statusConfig[order.status as keyof typeof statusConfig]
+            const status = statusConfig[order.status as keyof typeof statusConfig] || { icon: Clock, color: 'text-gray-600 bg-gray-100', label: order.status }
             const StatusIcon = status.icon
 
             return (

--- a/src/app/products/[id]/page.tsx
+++ b/src/app/products/[id]/page.tsx
@@ -1,7 +1,7 @@
 import { getProductById } from '@/actions/product'
 import { auth } from '@/lib/auth'
 import { AddToCartButton } from './AddToCartButton'
-import { Store, ArrowLeft, MapPin } from 'lucide-react'
+import { Store, ArrowLeft } from 'lucide-react'
 import Link from 'next/link'
 import { getMessage } from '@/lib/messages'
 

--- a/src/app/products/new/NewProductForm.tsx
+++ b/src/app/products/new/NewProductForm.tsx
@@ -3,7 +3,6 @@
 import { useState } from 'react'
 import { useRouter } from 'next/navigation'
 import { createProduct } from '@/actions/product'
-import { getMessage } from '@/lib/messages'
 import { Package, ArrowLeft } from 'lucide-react'
 
 import type { Category } from '@/types/database'

--- a/src/app/seller/balance/page.tsx
+++ b/src/app/seller/balance/page.tsx
@@ -1,0 +1,117 @@
+import { auth } from '@/lib/auth'
+import { redirect } from 'next/navigation'
+import { getSellerBalance, getPayoutHistory } from '@/actions/payment'
+import { getMessage } from '@/lib/messages'
+import { Clock, CheckCircle, TrendingUp } from 'lucide-react'
+
+export default async function SellerBalancePage() {
+  const session = await auth()
+  
+  if (!session?.user) {
+    redirect('/login')
+  }
+
+  if (session.user.role !== 'SELLER') {
+    redirect('/')
+  }
+
+  const balance = await getSellerBalance(session.user.id)
+  const payouts = await getPayoutHistory(session.user.id, 5)
+
+  return (
+    <div className="max-w-4xl mx-auto py-8 px-4">
+      <h1 className="text-3xl font-bold mb-2">{getMessage('seller.balance.title')}</h1>
+      <p className="text-muted-foreground mb-8">
+        Acompanhe suas finanças e recebimentos
+      </p>
+
+      <div className="grid md:grid-cols-3 gap-6 mb-8">
+        <div className="bg-card rounded-xl border p-6">
+          <div className="flex items-center gap-3 mb-2">
+            <div className="p-2 bg-green-100 rounded-lg">
+              <CheckCircle className="w-5 h-5 text-green-600" />
+            </div>
+            <span className="text-sm text-muted-foreground">Disponível</span>
+          </div>
+          <p className="text-3xl font-bold text-green-600">
+            R$ {balance.available.toFixed(2).replace('.', ',')}
+          </p>
+        </div>
+
+        <div className="bg-card rounded-xl border p-6">
+          <div className="flex items-center gap-3 mb-2">
+            <div className="p-2 bg-yellow-100 rounded-lg">
+              <Clock className="w-5 h-5 text-yellow-600" />
+            </div>
+            <span className="text-sm text-muted-foreground">Pendente</span>
+          </div>
+          <p className="text-3xl font-bold text-yellow-600">
+            R$ {balance.pending.toFixed(2).replace('.', ',')}
+          </p>
+        </div>
+
+        <div className="bg-card rounded-xl border p-6">
+          <div className="flex items-center gap-3 mb-2">
+            <div className="p-2 bg-blue-100 rounded-lg">
+              <TrendingUp className="w-5 h-5 text-blue-600" />
+            </div>
+            <span className="text-sm text-muted-foreground">Total Recebido</span>
+          </div>
+          <p className="text-3xl font-bold text-blue-600">
+            R$ {balance.totalPaid.toFixed(2).replace('.', ',')}
+          </p>
+        </div>
+      </div>
+
+      <div className="bg-card rounded-xl border p-6">
+        <h2 className="text-lg font-semibold mb-4">{getMessage('seller.balance.recentTransactions')}</h2>
+        
+        {payouts.length === 0 ? (
+          <p className="text-muted-foreground text-center py-8">
+            Nenhuma transação ainda.
+          </p>
+        ) : (
+          <div className="space-y-3">
+            {payouts.map((payout) => (
+              <div 
+                key={payout.id} 
+                className="flex items-center justify-between p-4 bg-muted rounded-lg"
+              >
+                <div>
+                  <p className="font-medium">
+                    R$ {payout.amount.toFixed(2).replace('.', ',')}
+                  </p>
+                  <p className="text-sm text-muted-foreground">
+                    {new Date(payout.createdAt).toLocaleDateString('pt-BR')}
+                  </p>
+                </div>
+                <div className="text-right">
+                  <span className={`inline-flex items-center px-2 py-1 rounded-full text-xs font-medium ${
+                    payout.status === 'SUCCESS' ? 'bg-green-100 text-green-800' :
+                    payout.status === 'PROCESSING' ? 'bg-yellow-100 text-yellow-800' :
+                    payout.status === 'FAILED' ? 'bg-red-100 text-red-800' :
+                    'bg-gray-100 text-gray-800'
+                  }`}>
+                    {payout.status === 'SUCCESS' ? 'Recebido' :
+                     payout.status === 'PROCESSING' ? 'Processando' :
+                     payout.status === 'FAILED' ? 'Falhou' :
+                     'Pendente'}
+                  </span>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+
+        {payouts.length > 0 && (
+          <a
+            href="/seller/payouts"
+            className="block mt-4 text-center text-primary hover:underline"
+          >
+            Ver histórico completo
+          </a>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/app/seller/orders/[id]/page.tsx
+++ b/src/app/seller/orders/[id]/page.tsx
@@ -2,7 +2,6 @@
 
 import { useState, useEffect } from 'react'
 import Link from 'next/link'
-import { useRouter } from 'next/navigation'
 import { ArrowLeft, Package, User, Calendar, FileText, Check, Clock, Truck, CheckCircle, XCircle } from 'lucide-react'
 import { getMessage } from '@/lib/messages'
 import { updateSellerOrderStatus, updateSellerOrderNote, updatePickupInstructions } from '@/actions/order'
@@ -58,7 +57,6 @@ interface SellerOrderData {
 }
 
 export default function SellerOrderDetailPage({ params }: Props) {
-  const router = useRouter()
   const [orderData, setOrderData] = useState<SellerOrderData | null>(null)
   const [loading, setLoading] = useState(true)
   const [saving, setSaving] = useState(false)

--- a/src/app/seller/orders/[id]/page.tsx
+++ b/src/app/seller/orders/[id]/page.tsx
@@ -26,6 +26,7 @@ const statusConfig: Record<string, { color: string; bg: string; icon: typeof Clo
 interface SellerOrderData {
   id: string
   orderId: string
+  sellerId: string
   status: OrderStatus
   note: string | null
   estimatedPickupDate: string | null
@@ -147,7 +148,7 @@ export default function SellerOrderDetailPage({ params }: Props) {
 
   // Calculate total for this seller's items
   const sellerItems = orderData.order.items.filter(
-    (item) => item.product.sellerId === orderData.id
+    (item) => item.product.sellerId === orderData.sellerId
   )
   const sellerTotal = sellerItems.reduce((sum, item) => sum + item.price * item.quantity, 0)
 

--- a/src/app/seller/orders/page.tsx
+++ b/src/app/seller/orders/page.tsx
@@ -1,7 +1,7 @@
 import { auth } from '@/lib/auth'
 import { redirect } from 'next/navigation'
 import Link from 'next/link'
-import { Package, ArrowRight, Inbox } from 'lucide-react'
+import { ArrowRight, Inbox } from 'lucide-react'
 import { getMessage } from '@/lib/messages'
 import { getSellerOrders, getSellerOrderCounts } from '@/actions/order'
 

--- a/src/app/seller/payment-settings/page.tsx
+++ b/src/app/seller/payment-settings/page.tsx
@@ -1,0 +1,165 @@
+import { auth } from '@/lib/auth'
+import { redirect } from 'next/navigation'
+import { getSellerPayment, setupSellerPayment } from '@/actions/payment'
+import { getMessage } from '@/lib/messages'
+import { revalidatePath } from 'next/cache'
+
+export default async function PaymentSettingsPage() {
+  const session = await auth()
+  
+  if (!session?.user) {
+    redirect('/login')
+  }
+
+  if (session.user.role !== 'SELLER') {
+    redirect('/')
+  }
+
+  const sellerPayment = await getSellerPayment(session.user.id)
+
+  return (
+    <div className="max-w-2xl mx-auto py-8 px-4">
+      <h1 className="text-3xl font-bold mb-2">{getMessage('seller.paymentSettings.title')}</h1>
+      <p className="text-muted-foreground mb-8">
+        {getMessage('seller.paymentSettings.description')}
+      </p>
+
+      <form action={async (formData) => {
+        'use server'
+        
+        const sessionData = await auth()
+        
+        const data = {
+          cpfCnpj: formData.get('cpfCnpj') as string,
+          pixKey: formData.get('pixKey') as string,
+          pixKeyType: formData.get('pixKeyType') as 'CPF' | 'CNPJ' | 'EMAIL' | 'TELEFONE',
+          pixBank: formData.get('pixBank') as string || undefined,
+          termsAccepted: formData.get('termsAccepted') === 'on',
+        }
+
+        const result = await setupSellerPayment(sessionData!.user.id, data)
+        
+        if (result.error) {
+          console.error('Payment setup error:', result.error)
+        }
+        
+        revalidatePath('/seller/payment-settings')
+      }} className="space-y-6">
+        <div className="bg-card rounded-xl border p-6 space-y-4">
+          <h2 className="text-lg font-semibold">{getMessage('seller.paymentSettings.pixInfo')}</h2>
+          
+          <div className="grid gap-4">
+            <div>
+              <label htmlFor="cpfCnpj" className="block text-sm font-medium mb-2">
+                {getMessage('seller.paymentSettings.cpfCnpj')}
+              </label>
+              <input
+                id="cpfCnpj"
+                name="cpfCnpj"
+                type="text"
+                defaultValue={sellerPayment?.cpfCnpj || ''}
+                placeholder="123.456.789-00 ou 12.345.678/0001-90"
+                className="w-full px-4 py-2 rounded-lg border bg-background focus:outline-none focus:ring-2 focus:ring-primary"
+                required
+              />
+            </div>
+
+            <div>
+              <label htmlFor="pixKeyType" className="block text-sm font-medium mb-2">
+                {getMessage('seller.paymentSettings.pixKeyType')}
+              </label>
+              <select
+                id="pixKeyType"
+                name="pixKeyType"
+                defaultValue={sellerPayment?.pixKeyType || ''}
+                className="w-full px-4 py-2 rounded-lg border bg-background focus:outline-none focus:ring-2 focus:ring-primary"
+                required
+              >
+                <option value="">{getMessage('seller.paymentSettings.selectType')}</option>
+                <option value="CPF">CPF</option>
+                <option value="CNPJ">CNPJ</option>
+                <option value="EMAIL">E-mail</option>
+                <option value="TELEFONE">Telefone</option>
+              </select>
+            </div>
+
+            <div>
+              <label htmlFor="pixKey" className="block text-sm font-medium mb-2">
+                {getMessage('seller.paymentSettings.pixKey')}
+              </label>
+              <input
+                id="pixKey"
+                name="pixKey"
+                type="text"
+                defaultValue={sellerPayment?.pixKey || ''}
+                placeholder={sellerPayment?.pixKey || getMessage('seller.paymentSettings.pixKeyPlaceholder')}
+                className="w-full px-4 py-2 rounded-lg border bg-background focus:outline-none focus:ring-2 focus:ring-primary"
+                required
+              />
+              {sellerPayment?.pixKeyMasked && (
+                <p className="text-sm text-muted-foreground mt-1">
+                  Chave atual: {sellerPayment.pixKeyMasked}
+                </p>
+              )}
+            </div>
+
+            <div>
+              <label htmlFor="pixBank" className="block text-sm font-medium mb-2">
+                {getMessage('seller.paymentSettings.pixBank')} (opcional)
+              </label>
+              <input
+                id="pixBank"
+                name="pixBank"
+                type="text"
+                defaultValue={sellerPayment?.pixBank || ''}
+                placeholder="Nubank, Itaú, Banco do Brasil, etc."
+                className="w-full px-4 py-2 rounded-lg border bg-background focus:outline-none focus:ring-2 focus:ring-primary"
+              />
+            </div>
+          </div>
+        </div>
+
+        <div className="bg-card rounded-xl border p-6">
+          <h2 className="text-lg font-semibold mb-4">{getMessage('seller.paymentSettings.terms')}</h2>
+          <div className="prose prose-sm text-muted-foreground mb-4">
+            <p>Ao aceitar estes termos, você concorda com:</p>
+            <ul className="list-disc pl-4 space-y-1">
+              <li>Taxa de comissão de 10% sobre cada venda</li>
+              <li>Taxa fixa de R$ 1,00 por transação (R$ 0,80 AbacatePay + R$ 0,20 Plataforma)</li>
+              <li>Recebimento via PIX após confirmação do pagamento</li>
+              <li>Responsabilidade pela precisão dos dados cadastrais</li>
+            </ul>
+          </div>
+          <label className="flex items-center gap-3 cursor-pointer">
+            <input
+              type="checkbox"
+              name="termsAccepted"
+              defaultChecked={sellerPayment?.termsAccepted || false}
+              className="w-5 h-5 rounded border-gray-300 text-primary focus:ring-primary"
+              required
+            />
+            <span className="text-sm">
+              {getMessage('seller.paymentSettings.acceptTerms')}
+            </span>
+          </label>
+        </div>
+
+        <button
+          type="submit"
+          className="w-full bg-primary text-primary-foreground py-3 rounded-lg hover:bg-primary/90 transition-colors font-medium"
+        >
+          {getMessage('seller.paymentSettings.save')}
+        </button>
+
+        {sellerPayment && (
+          <div className="mt-4 p-4 bg-muted rounded-lg">
+            <p className="text-sm text-muted-foreground">
+              Status: {sellerPayment.isActive ? 'Ativo' : 'Inativo'}
+              {sellerPayment.isVerified && ' • Verificado'}
+            </p>
+          </div>
+        )}
+      </form>
+    </div>
+  )
+}

--- a/src/app/seller/payouts/PayoutHistoryClient.tsx
+++ b/src/app/seller/payouts/PayoutHistoryClient.tsx
@@ -1,0 +1,99 @@
+'use client'
+
+import { useState } from 'react'
+import { retryPayout } from '@/actions/payment'
+import { getMessage } from '@/lib/messages'
+import { RefreshCw, CheckCircle, XCircle, Clock, AlertCircle } from 'lucide-react'
+
+interface Payout {
+  id: string
+  amount: number
+  status: string
+  createdAt: Date
+  processedAt: Date | null
+  errorMessage: string | null
+}
+
+export function PayoutHistoryClient({ initialPayouts }: { initialPayouts: Payout[] }) {
+  const payouts = initialPayouts
+  const [retrying, setRetrying] = useState<string | null>(null)
+
+  async function handleRetry(payoutId: string) {
+    setRetrying(payoutId)
+    await retryPayout(payoutId)
+    setRetrying(null)
+  }
+
+  return (
+    <div>
+      <h1 className="text-3xl font-bold mb-8">{getMessage('seller.payouts.title')}</h1>
+
+      {payouts.length === 0 ? (
+        <div className="bg-card rounded-xl border p-8 text-center">
+          <p className="text-muted-foreground">Nenhum repasse realizado ainda.</p>
+        </div>
+      ) : (
+        <div className="bg-card rounded-xl border overflow-hidden">
+          <table className="w-full">
+            <thead className="bg-muted">
+              <tr>
+                <th className="text-left px-6 py-3 text-sm font-medium">Data</th>
+                <th className="text-left px-6 py-3 text-sm font-medium">Valor</th>
+                <th className="text-left px-6 py-3 text-sm font-medium">Status</th>
+                <th className="text-right px-6 py-3 text-sm font-medium">Ações</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y">
+              {payouts.map((payout) => (
+                <tr key={payout.id}>
+                  <td className="px-6 py-4">
+                    {new Date(payout.createdAt).toLocaleDateString('pt-BR', {
+                      day: '2-digit',
+                      month: '2-digit',
+                      year: 'numeric',
+                    })}
+                  </td>
+                  <td className="px-6 py-4 font-medium">
+                    R$ {payout.amount.toFixed(2).replace('.', ',')}
+                  </td>
+                  <td className="px-6 py-4">
+                    <span className={`inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-medium ${
+                      payout.status === 'SUCCESS' ? 'bg-green-100 text-green-800' :
+                      payout.status === 'PROCESSING' ? 'bg-yellow-100 text-yellow-800' :
+                      payout.status === 'FAILED' ? 'bg-red-100 text-red-800' :
+                      'bg-gray-100 text-gray-800'
+                    }`}>
+                      {payout.status === 'SUCCESS' && <CheckCircle className="w-3.5 h-3.5" />}
+                      {payout.status === 'PROCESSING' && <Clock className="w-3.5 h-3.5" />}
+                      {payout.status === 'FAILED' && <XCircle className="w-3.5 h-3.5" />}
+                      {payout.status === 'PENDING' && <AlertCircle className="w-3.5 h-3.5" />}
+                      {payout.status === 'SUCCESS' ? 'Recebido' :
+                       payout.status === 'PROCESSING' ? 'Processando' :
+                       payout.status === 'FAILED' ? 'Falhou' :
+                       'Pendente'}
+                    </span>
+                  </td>
+                  <td className="px-6 py-4 text-right">
+                    {payout.status === 'FAILED' && (
+                      <button
+                        onClick={() => handleRetry(payout.id)}
+                        disabled={retrying === payout.id}
+                        className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm bg-primary text-primary-foreground rounded-lg hover:bg-primary/90 disabled:opacity-50"
+                      >
+                        <RefreshCw className={`w-3.5 h-3.5 ${retrying === payout.id ? 'animate-spin' : ''}`} />
+                        {getMessage('seller.payouts.retry')}
+                      </button>
+                    )}
+                    {payout.errorMessage && payout.status === 'FAILED' && (
+                      <p className="text-xs text-red-500 mt-1">{payout.errorMessage}</p>
+                    )}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/app/seller/payouts/page.tsx
+++ b/src/app/seller/payouts/page.tsx
@@ -1,0 +1,28 @@
+import { auth } from '@/lib/auth'
+import { redirect } from 'next/navigation'
+import { getPayoutHistory } from '@/actions/payment'
+import { PayoutHistoryClient } from './PayoutHistoryClient'
+
+export default async function PayoutsPage() {
+  const session = await auth()
+  
+  if (!session?.user) {
+    redirect('/login')
+  }
+
+  if (session.user.role !== 'SELLER') {
+    redirect('/')
+  }
+
+  const payouts = await getPayoutHistory(session.user.id)
+
+  return (
+    <PayoutHistoryClient 
+      initialPayouts={payouts.map(p => ({
+        ...p,
+        createdAt: p.createdAt,
+        processedAt: p.processedAt,
+      }))} 
+    />
+  )
+}

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,6 +1,6 @@
 import Link from 'next/link'
 import { auth, signOut } from '@/lib/auth'
-import { ShoppingCart, Package, User, LogOut, Plus, ClipboardList } from 'lucide-react'
+import { ShoppingCart, Package, User, LogOut, Plus, ClipboardList, Wallet, CreditCard } from 'lucide-react'
 import { getMessage } from '@/lib/messages'
 
 export default async function Navbar() {
@@ -33,6 +33,14 @@ export default async function Navbar() {
                   <Link href="/seller/orders" className="hover:text-primary flex items-center gap-1 transition-colors">
                     <ClipboardList className="w-4 h-4" />
                     {getMessage('seller_orders.title')}
+                  </Link>
+                  <Link href="/seller/balance" className="hover:text-primary flex items-center gap-1 transition-colors">
+                    <Wallet className="w-4 h-4" />
+                    Saldo
+                  </Link>
+                  <Link href="/seller/payment-settings" className="hover:text-primary flex items-center gap-1 transition-colors">
+                    <CreditCard className="w-4 h-4" />
+                    PIX
                   </Link>
                   <Link href="/products/new" className="hover:text-primary flex items-center gap-1 transition-colors">
                     <Plus className="w-4 h-4" />

--- a/src/lib/abacatepay.ts
+++ b/src/lib/abacatepay.ts
@@ -1,0 +1,201 @@
+import crypto from 'crypto'
+
+const ABACATEPAY_BASE_URL = process.env.ABACATEPAY_ENV === 'production' 
+  ? 'https://api.abacatepay.com/v1'
+  : 'https://sandbox.abacatepay.com/v1'
+
+interface AbacatePayCustomer {
+  name: string
+  email: string
+  document: string
+}
+
+interface AbacatePayProduct {
+  name: string
+  value: number
+  amount: number
+}
+
+interface CreateChargeRequest {
+  frequency: 'ONE_TIME' | 'RECURRENT'
+  methods: ['PIX']
+  products: AbacatePayProduct[]
+  customer: AbacatePayCustomer
+  returnUrl?: string
+  completionUrl?: string
+}
+
+interface CreateChargeResponse {
+  id: string
+  status: 'PENDING' | 'WAITING' | 'CONFIRMED' | 'FAILED' | 'CANCELED'
+  createdAt: string
+  updatedAt: string
+  expiresAt: string
+  frequency: string
+  methods: string[]
+  products: Array<{
+    name: string
+    value: number
+    amount: number
+  }>
+  customer: {
+    name: string
+    email: string
+    document: string
+  }
+  paidAt?: string
+  pix?: {
+    qrCode: string
+    copyPaste: string
+    expiresAt: string
+  }
+}
+
+interface GetChargeResponse {
+  id: string
+  status: 'PENDING' | 'WAITING' | 'CONFIRMED' | 'FAILED' | 'CANCELED'
+  paidAt?: string
+  pix?: {
+    qrCode: string
+    copyPaste: string
+  }
+}
+
+function getApiKey(): string {
+  return process.env.ABACATEPAY_API_KEY || ''
+}
+
+function isMockMode(): boolean {
+  return process.env.MOCK_PAYMENTS === 'true'
+}
+
+export async function createPixCharge(request: CreateChargeRequest): Promise<CreateChargeResponse> {
+  if (isMockMode() || !getApiKey()) {
+    console.log('[AbacatePay Mock] Creating PIX charge:', request)
+    return createMockCharge(request)
+  }
+
+  const response = await fetch(`${ABACATEPAY_BASE_URL}/billing/create`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${getApiKey()}`,
+    },
+    body: JSON.stringify(request),
+  })
+
+  if (!response.ok) {
+    const error = await response.text()
+    throw new Error(`AbacatePay error: ${response.status} - ${error}`)
+  }
+
+  return response.json()
+}
+
+export async function getChargeStatus(chargeId: string): Promise<GetChargeResponse> {
+  if (isMockMode() || !getApiKey()) {
+    console.log('[AbacatePay Mock] Getting charge status:', chargeId)
+    return getMockChargeStatus(chargeId)
+  }
+
+  const response = await fetch(`${ABACATEPAY_BASE_URL}/billing/${chargeId}`, {
+    method: 'GET',
+    headers: {
+      'Authorization': `Bearer ${getApiKey()}`,
+    },
+  })
+
+  if (!response.ok) {
+    const error = await response.text()
+    throw new Error(`AbacatePay error: ${response.status} - ${error}`)
+  }
+
+  return response.json()
+}
+
+export function validateWebhookSignature(payload: string, signature: string): boolean {
+  const secret = process.env.ABACATEPAY_WEBHOOK_SECRET
+  if (!secret) {
+    console.warn('[AbacatePay] Webhook secret not configured')
+    return false
+  }
+
+  const expectedSignature = crypto
+    .createHmac('sha256', secret)
+    .update(payload)
+    .digest('hex')
+
+  const sigBuffer = Buffer.from(signature)
+  const expectedBuffer = Buffer.from(expectedSignature)
+  if (sigBuffer.length !== expectedBuffer.length) return false
+  return crypto.timingSafeEqual(sigBuffer, expectedBuffer)
+}
+
+const mockCharges = new Map<string, CreateChargeResponse>()
+
+function createMockCharge(request: CreateChargeRequest): CreateChargeResponse {
+  const chargeId = `mock_charge_${Date.now()}_${Math.random().toString(36).slice(2, 11)}`
+  
+  const mockCharge: CreateChargeResponse = {
+    id: chargeId,
+    status: 'PENDING',
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    expiresAt: new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString(),
+    frequency: request.frequency,
+    methods: ['PIX'],
+    products: request.products,
+    customer: request.customer,
+    pix: {
+      qrCode: `00020101021226360014br.gov.bcb.pix0136${chargeId}5204000053039865802BR5925MOCK MERCHANT6009SAO_PAULO61080540000162070503***6304`,
+      copyPaste: `00020101021226360014br.gov.bcb.pix0136${chargeId}5204000053039865802BR5925MOCK MERCHANT6009SAO_PAULO61080540000162070503***6304`,
+      expiresAt: new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString(),
+    },
+  }
+
+  mockCharges.set(chargeId, mockCharge)
+  console.log('[AbacatePay Mock] Created charge:', chargeId)
+
+  setTimeout(() => {
+    const charge = mockCharges.get(chargeId)
+    if (charge && charge.status === 'PENDING') {
+      charge.status = 'WAITING'
+      charge.updatedAt = new Date().toISOString()
+      console.log('[AbacatePay Mock] Charge waiting:', chargeId)
+    }
+  }, 2000)
+
+  return mockCharge
+}
+
+function getMockChargeStatus(chargeId: string): GetChargeResponse {
+  const mock = mockCharges.get(chargeId)
+  
+  if (!mock) {
+    return {
+      id: chargeId,
+      status: 'FAILED',
+    }
+  }
+
+  return {
+    id: mock.id,
+    status: mock.status,
+    paidAt: mock.status === 'CONFIRMED' ? mock.updatedAt : undefined,
+    pix: mock.pix,
+  }
+}
+
+export function simulateMockPaymentConfirmation(chargeId: string): void {
+  const charge = mockCharges.get(chargeId)
+  if (charge) {
+    charge.status = 'CONFIRMED'
+    charge.paidAt = new Date().toISOString()
+    charge.updatedAt = new Date().toISOString()
+    console.log('[AbacatePay Mock] Payment confirmed:', chargeId)
+  }
+}
+
+export function getMockCharge(chargeId: string): CreateChargeResponse | undefined {
+  return mockCharges.get(chargeId)
+}

--- a/src/lib/encryption.ts
+++ b/src/lib/encryption.ts
@@ -1,0 +1,145 @@
+import crypto from 'crypto'
+
+const ALGORITHM = 'aes-256-gcm'
+const IV_LENGTH = 16
+
+function getEncryptionKey(): Buffer {
+  const key = process.env.PIX_ENCRYPTION_KEY
+  if (!key) {
+    throw new Error('PIX_ENCRYPTION_KEY environment variable is not set')
+  }
+  
+  const keyBuffer = Buffer.from(key, 'hex')
+  if (keyBuffer.length !== 32) {
+    throw new Error('PIX_ENCRYPTION_KEY must be 64 hex characters (32 bytes)')
+  }
+  
+  return keyBuffer
+}
+
+export function encryptPIXKey(pixKey: string): string {
+  const key = getEncryptionKey()
+  const iv = crypto.randomBytes(IV_LENGTH)
+  const cipher = crypto.createCipheriv(ALGORITHM, key, iv)
+  
+  let encrypted = cipher.update(pixKey, 'utf8', 'hex')
+  encrypted += cipher.final('hex')
+  
+  const authTag = cipher.getAuthTag()
+  
+  return `${iv.toString('hex')}:${authTag.toString('hex')}:${encrypted}`
+}
+
+export function decryptPIXKey(encryptedData: string): string {
+  const key = getEncryptionKey()
+  const [ivHex, authTagHex, encrypted] = encryptedData.split(':')
+  
+  if (!ivHex || !authTagHex || !encrypted) {
+    throw new Error('Invalid encrypted PIX key format')
+  }
+  
+  const iv = Buffer.from(ivHex, 'hex')
+  const authTag = Buffer.from(authTagHex, 'hex')
+  
+  const decipher = crypto.createDecipheriv(ALGORITHM, key, iv)
+  decipher.setAuthTag(authTag)
+  
+  let decrypted = decipher.update(encrypted, 'hex', 'utf8')
+  decrypted += decipher.final('utf8')
+  
+  return decrypted
+}
+
+export function validateCPF(cpf: string): boolean {
+  const cleanCPF = cpf.replace(/\D/g, '')
+  
+  if (cleanCPF.length !== 11) return false
+  if (/^(\d)\1{10}$/.test(cleanCPF)) return false
+  
+  let sum = 0
+  for (let i = 0; i < 9; i++) {
+    sum += parseInt(cleanCPF[i]) * (10 - i)
+  }
+  
+  let remainder = sum % 11
+  const firstDigit = remainder < 2 ? 0 : 11 - remainder
+  
+  if (parseInt(cleanCPF[9]) !== firstDigit) return false
+  
+  sum = 0
+  for (let i = 0; i < 10; i++) {
+    sum += parseInt(cleanCPF[i]) * (11 - i)
+  }
+  
+  remainder = sum % 11
+  const secondDigit = remainder < 2 ? 0 : 11 - remainder
+  
+  return parseInt(cleanCPF[10]) === secondDigit
+}
+
+export function validateCNPJ(cnpj: string): boolean {
+  const cleanCNPJ = cnpj.replace(/\D/g, '')
+  
+  if (cleanCNPJ.length !== 14) return false
+  if (/^(\d)\1{13}$/.test(cleanCNPJ)) return false
+  
+  const weights1 = [5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2]
+  const weights2 = [6, 5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2]
+  
+  let sum = 0
+  for (let i = 0; i < 12; i++) {
+    sum += parseInt(cleanCNPJ[i]) * weights1[i]
+  }
+  
+  let remainder = sum % 11
+  const firstDigit = remainder < 2 ? 0 : 11 - remainder
+  
+  if (parseInt(cleanCNPJ[12]) !== firstDigit) return false
+  
+  sum = 0
+  for (let i = 0; i < 13; i++) {
+    sum += parseInt(cleanCNPJ[i]) * weights2[i]
+  }
+  
+  remainder = sum % 11
+  const secondDigit = remainder < 2 ? 0 : 11 - remainder
+  
+  return parseInt(cleanCNPJ[13]) === secondDigit
+}
+
+export function validatePixKey(key: string, type: 'CPF' | 'CNPJ' | 'EMAIL' | 'TELEFONE'): boolean {
+  switch (type) {
+    case 'CPF':
+      return validateCPF(key)
+    case 'CNPJ':
+      return validateCNPJ(key)
+    case 'EMAIL':
+      return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(key)
+    case 'TELEFONE':
+      const cleanPhone = key.replace(/\D/g, '')
+      return cleanPhone.length >= 10 && cleanPhone.length <= 11
+    default:
+      return false
+  }
+}
+
+export function formatCPF(cpf: string): string {
+  const clean = cpf.replace(/\D/g, '')
+  return clean.replace(/(\d{3})(\d{3})(\d{3})(\d{2})/, '$1.$2.$3-$4')
+}
+
+export function formatCNPJ(cnpj: string): string {
+  const clean = cnpj.replace(/\D/g, '')
+  return clean.replace(/(\d{2})(\d{3})(\d{3})(\d{4})(\d{2})/, '$1.$2.$3/$4-$5')
+}
+
+export function formatPhone(phone: string): string {
+  const clean = phone.replace(/\D/g, '')
+  if (clean.length === 10) {
+    return clean.replace(/(\d{2})(\d{4})(\d{4})/, '($1) $2-$3')
+  }
+  if (clean.length === 11) {
+    return clean.replace(/(\d{2})(\d{5})(\d{4})/, '($1) $2-$3')
+  }
+  return phone
+}

--- a/src/lib/messages.ts
+++ b/src/lib/messages.ts
@@ -186,8 +186,6 @@ export const messages = {
   }
 }
 
-type MessageKey = keyof typeof messages
-
 export function t(key: string): string {
   const keys = key.split('.')
   let result: unknown = messages

--- a/src/lib/messages.ts
+++ b/src/lib/messages.ts
@@ -100,7 +100,35 @@ export const messages = {
     description: 'Conheça quem está por trás deste produto',
     products: 'Produtos deste produtor',
     contact: 'Entrar em contato',
-    rating: 'Avaliação'
+    rating: 'Avaliação',
+    paymentSettings: {
+      title: 'Configurações de Pagamento',
+      description: 'Configure sua chave PIX para receber seus pagamentos.',
+      pixInfo: 'Informações do PIX',
+      cpfCnpj: 'CPF ou CNPJ',
+      pixKeyType: 'Tipo de chave PIX',
+      selectType: 'Selecione o tipo',
+      pixKey: 'Chave PIX',
+      pixKeyPlaceholder: 'Sua chave PIX',
+      pixBank: 'Banco ou Instituição',
+      terms: 'Termos e Condições',
+      acceptTerms: 'Eu aceito os termos e condições de uso',
+      save: 'Salvar Configurações'
+    },
+    balance: {
+      title: 'Meu Saldo',
+      available: 'Saldo Disponível',
+      pending: 'Pendente',
+      totalPaid: 'Total Recebido',
+      recentTransactions: 'Transações Recentes'
+    },
+    payouts: {
+      title: 'Histórico de Repasses',
+      amount: 'Valor',
+      status: 'Status',
+      date: 'Data',
+      retry: 'Tentar Novamente'
+    }
   },
 
   seller_orders: {

--- a/src/lib/pagseguro.ts
+++ b/src/lib/pagseguro.ts
@@ -1,0 +1,171 @@
+import crypto from 'crypto'
+
+const PAGSEGURO_BASE_URL = process.env.PAGSEGURO_ENV === 'production'
+  ? 'https://ws.pagseguro.uol.com.br/v2'
+  : 'https://ws.sandbox.pagseguro.uol.com.br/v2'
+
+interface PayoutRequest {
+  pixKey: string
+  pixKeyType: 'CPF' | 'CNPJ' | 'EMAIL' | 'TELEFONE'
+  amount: number
+  referenceId: string
+  description?: string
+}
+
+interface PayoutResponse {
+  id: string
+  status: 'PENDING' | 'PROCESSING' | 'SUCCESS' | 'FAILED'
+  referenceId: string
+  amount: number
+  createdAt: string
+  processedAt?: string
+  errorMessage?: string
+}
+
+function getCredentials(): { email: string; token: string } {
+  return {
+    email: process.env.PAGSEGURO_EMAIL || '',
+    token: process.env.PAGSEGURO_TOKEN || '',
+  }
+}
+
+function isMockMode(): boolean {
+  return process.env.MOCK_PAYMENTS === 'true'
+}
+
+export async function createPayout(request: PayoutRequest): Promise<PayoutResponse> {
+  if (isMockMode() || !getCredentials().token) {
+    console.log('[PagSeguro Mock] Creating payout:', request)
+    return createMockPayout(request)
+  }
+
+  const { email, token } = getCredentials()
+  const params = new URLSearchParams({
+    email,
+    token,
+    pixKey: request.pixKey,
+    pixKeyType: request.pixKeyType,
+    amount: request.amount.toFixed(2),
+    referenceId: request.referenceId,
+  })
+
+  if (request.description) {
+    params.append('description', request.description)
+  }
+
+  const response = await fetch(`${PAGSEGURO_BASE_URL}/payouts?${params}`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  })
+
+  if (!response.ok) {
+    const error = await response.text()
+    throw new Error(`PagSeguro error: ${response.status} - ${error}`)
+  }
+
+  return response.json()
+}
+
+export async function getPayoutStatus(payoutId: string): Promise<PayoutResponse> {
+  if (isMockMode() || !getCredentials().token) {
+    console.log('[PagSeguro Mock] Getting payout status:', payoutId)
+    return getMockPayoutStatus(payoutId)
+  }
+
+  const { email, token } = getCredentials()
+  const params = new URLSearchParams({
+    email,
+    token,
+  })
+
+  const response = await fetch(`${PAGSEGURO_BASE_URL}/payouts/${payoutId}?${params}`, {
+    method: 'GET',
+  })
+
+  if (!response.ok) {
+    const error = await response.text()
+    throw new Error(`PagSeguro error: ${response.status} - ${error}`)
+  }
+
+  return response.json()
+}
+
+export function validateWebhookSignature(payload: string, signature: string): boolean {
+  const token = process.env.PAGSEGURO_WEBHOOK_SECRET
+  if (!token) {
+    console.warn('[PagSeguro] Webhook token not configured')
+    return false
+  }
+
+  const expectedSignature = crypto
+    .createHmac('sha256', token)
+    .update(payload)
+    .digest('hex')
+
+  const sigBuffer = Buffer.from(signature)
+  const expectedBuffer = Buffer.from(expectedSignature)
+  if (sigBuffer.length !== expectedBuffer.length) return false
+  return crypto.timingSafeEqual(sigBuffer, expectedBuffer)
+}
+
+const mockPayouts = new Map<string, PayoutResponse>()
+
+function createMockPayout(request: PayoutRequest): PayoutResponse {
+  const payoutId = `mock_payout_${Date.now()}_${Math.random().toString(36).slice(2, 11)}`
+  
+  const mockPayout: PayoutResponse = {
+    id: payoutId,
+    status: 'PENDING',
+    referenceId: request.referenceId,
+    amount: request.amount,
+    createdAt: new Date().toISOString(),
+  }
+
+  mockPayouts.set(payoutId, mockPayout)
+  console.log('[PagSeguro Mock] Created payout:', payoutId)
+
+  setTimeout(() => {
+    const payout = mockPayouts.get(payoutId)
+    if (payout && payout.status === 'PENDING') {
+      payout.status = 'PROCESSING'
+      console.log('[PagSeguro Mock] Payout processing:', payoutId)
+    }
+  }, 1500)
+
+  setTimeout(() => {
+    const payout = mockPayouts.get(payoutId)
+    if (payout && payout.status === 'PROCESSING') {
+      payout.status = 'SUCCESS'
+      payout.processedAt = new Date().toISOString()
+      console.log('[PagSeguro Mock] Payout success:', payoutId)
+    }
+  }, 3000)
+
+  return mockPayout
+}
+
+function getMockPayoutStatus(payoutId: string): PayoutResponse {
+  return mockPayouts.get(payoutId) || {
+    id: payoutId,
+    status: 'FAILED',
+    referenceId: '',
+    amount: 0,
+    createdAt: new Date().toISOString(),
+    errorMessage: 'Payout not found',
+  }
+}
+
+export function simulateMockPayoutSuccess(payoutId: string): void {
+  const payout = mockPayouts.get(payoutId)
+  if (payout) {
+    payout.status = 'SUCCESS'
+    payout.processedAt = new Date().toISOString()
+    console.log('[PagSeguro Mock] Payout confirmed:', payoutId)
+  }
+}
+
+export function getMockPayout(payoutId: string): PayoutResponse | undefined {
+  return mockPayouts.get(payoutId)
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -28,7 +28,8 @@
     "**/*.tsx",
     ".next/types/**/*.ts",
     ".next/dev/types/**/*.ts",
-    "**/*.mts"
+    "**/*.mts",
+    "node_modules/.prisma/client/index.d.ts"
   ],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
## Summary
- Implements PIX payment checkout flow via AbacatePay with QR Code generation
- Adds automatic payment split with 10% platform commission between sellers
- Integrates PagSeguro Payout API for seller PIX transfers
- Fixes 10 bugs found during code review (critical race conditions, wrong filters, missing error handling)

## Changes

### Payment System
- `src/actions/checkout.ts` — atomic checkout with inventory management
- `src/actions/payment.ts` — payment creation, split, payout, balance calculation
- `src/lib/abacatepay.ts` — AbacatePay API integration (mock mode for dev)
- `src/lib/pagseguro.ts` — PagSeguro Payout API integration (mock mode for dev)
- `src/lib/encryption.ts` — PIX key encryption/decryption with AES-256-GCM

### Webhooks
- `src/app/api/webhooks/abacatepay/route.ts` — payment confirmation webhook
- `src/app/api/webhooks/pagseguro/route.ts` — payout status webhook

### New Pages
- `/checkout` — checkout flow with PIX payment
- `/checkout/waiting/[id]` — payment waiting page with QR Code
- `/seller/payment-settings` — seller PIX configuration
- `/seller/balance` — seller balance dashboard
- `/seller/payouts` — payout history with retry

### Bug Fixes
- **Critical:** Seller order detail filter compared `sellerId` against `SellerOrder.id` instead of seller's userId
- **Critical:** Non-atomic checkout created race condition between cart deletion and inventory decrement
- **Critical:** Balance calculation incorrectly included SENT/PROCESSING splits as "available" money
- **High:** `crypto.timingSafeEqual` crash when webhook signature buffers have different lengths
- **Medium:** Missing error handling in `updateProduct` and `createCategory` server actions
- **Medium:** `revalidatePath` used template literal `[id]` instead of actual payment ID
- **Medium:** Misleading `payoutStatus: { not: null }` filter in `getSellerBalance`

### Database
- New Prisma migration: `SellerPayment`, `Payment`, `PaymentSplit`, `Payout` models
- Idempotent seed script with cleanup

## Test Accounts
| Role | Email | Password |
|------|-------|----------|
| Seller | joao.silva@email.com | senha123 |
| Seller | maria.santos@email.com | senha123 |
| Seller | pedro.oliveira@email.com | senha123 |
| Seller | ana.ferreira@email.com | senha123 |
| Buyer | comprador@email.com | senha123 |

## Related Issues
Closes #9

## Notes
- Both AbacatePay and PagSeguro run in **mock mode** by default (`MOCK_PAYMENTS=true`)
- Set `ABACATEPAY_API_KEY` and `PAGSEGURO_TOKEN` in `.env` for real payment integration
- Run `npx prisma migrate deploy && npm run db:seed` to apply migrations and seed data